### PR TITLE
[Sanity Check] No Current Branch

### DIFF
--- a/src/commands/fix/index.ts
+++ b/src/commands/fix/index.ts
@@ -18,6 +18,9 @@ export default class FixCommand extends AbstractCommand<typeof args> {
   static args = args;
   public async _execute(argv: argsT): Promise<void> {
     const branch = Branch.getCurrentBranch();
+    if (branch === null) {
+      return;
+    }
 
     printBranchNameStack(
       `(Original git derived stack)`,

--- a/src/commands/next-or-prev/index.ts
+++ b/src/commands/next-or-prev/index.ts
@@ -2,6 +2,7 @@
 import chalk from "chalk";
 import { execSync } from "child_process";
 import yargs from "yargs";
+import { logErrorAndExit } from "../../lib/utils";
 import Branch from "../../wrapper-classes/branch";
 import AbstractCommand from "../abstract_command";
 
@@ -22,6 +23,9 @@ export class PrevCommand extends AbstractCommand<typeof args> {
 
 async function nextOrPrev(nextOrPrev: "next" | "prev") {
   const currentBranch = Branch.getCurrentBranch();
+  if (currentBranch === null) {
+    logErrorAndExit(`Not currently on branch, cannot find ${nextOrPrev}.`);
+  }
 
   const candidates =
     nextOrPrev === "next"

--- a/src/commands/print-stacks/index.ts
+++ b/src/commands/print-stacks/index.ts
@@ -44,6 +44,8 @@ export default class PrintStacksCommand extends AbstractCommand<typeof args> {
     if (currentBranch) {
       console.log(`Current branch: ${chalk.green(`(${currentBranch.name})`)}`);
     }
+    const currentBranchName =
+      currentBranch !== null ? currentBranch.name : null;
 
     const dagsAreEqual =
       Object.keys(gitInfo.dag).length == Object.keys(metaInfo.dag).length &&
@@ -55,7 +57,7 @@ export default class PrintStacksCommand extends AbstractCommand<typeof args> {
     if (dagsAreEqual) {
       gitInfo.sourceBranches.forEach((sourceBranch) => {
         dfsPrintBranches({
-          currentBranchName: currentBranch.name,
+          currentBranchName: currentBranchName,
           branchName: sourceBranch,
           dag: gitInfo.dag,
           depthIndents: [],
@@ -76,7 +78,7 @@ export default class PrintStacksCommand extends AbstractCommand<typeof args> {
       console.log(`Git derived stacks:`);
       gitInfo.sourceBranches.forEach((sourceBranch) => {
         dfsPrintBranches({
-          currentBranchName: currentBranch.name,
+          currentBranchName: currentBranchName,
           branchName: sourceBranch,
           dag: gitInfo.dag,
           depthIndents: [],
@@ -86,7 +88,7 @@ export default class PrintStacksCommand extends AbstractCommand<typeof args> {
       console.log(`Meta derived stacks:`);
       metaInfo.sourceBranches.forEach((sourceBranch) => {
         dfsPrintBranches({
-          currentBranchName: currentBranch.name,
+          currentBranchName: currentBranchName,
           branchName: sourceBranch,
           dag: metaInfo.dag,
           depthIndents: [],
@@ -97,7 +99,7 @@ export default class PrintStacksCommand extends AbstractCommand<typeof args> {
 }
 
 function dfsPrintBranches(args: {
-  currentBranchName: string;
+  currentBranchName: string | null;
   branchName: string;
   parentName?: string;
   dag: { [name: string]: string[] };

--- a/src/commands/restack/index.ts
+++ b/src/commands/restack/index.ts
@@ -2,7 +2,11 @@ import chalk from "chalk";
 import { execSync } from "child_process";
 import yargs from "yargs";
 import { log } from "../../lib/log";
-import { CURRENT_REPO_CONFIG_PATH, trunkBranches } from "../../lib/utils";
+import {
+  CURRENT_REPO_CONFIG_PATH,
+  logErrorAndExit,
+  trunkBranches,
+} from "../../lib/utils";
 import Branch from "../../wrapper-classes/branch";
 import AbstractCommand from "../abstract_command";
 import PrintStacksCommand from "../print-stacks";
@@ -47,6 +51,10 @@ export default class RestackCommand extends AbstractCommand<typeof args> {
     !argv.silent && (await new PrintStacksCommand().executeUnprofiled(args));
 
     const originalBranch = Branch.getCurrentBranch();
+    if (originalBranch === null) {
+      logErrorAndExit(`Not currently on a branch; no target to restack.`);
+    }
+
     if (argv.onto) {
       await restackOnto(originalBranch, argv.onto, argv);
     } else {

--- a/src/commands/submit/index.ts
+++ b/src/commands/submit/index.ts
@@ -56,9 +56,11 @@ export default class SubmitCommand extends AbstractCommand<typeof args> {
       throw new Error(`Validation failed before submitting.`);
     }
 
-    let currentBranch: Branch | undefined = Branch.getCurrentBranch();
+    let currentBranch: Branch | undefined | null = Branch.getCurrentBranch();
+
     const stackOfBranches: Branch[] = [];
     while (
+      currentBranch != null &&
       currentBranch != undefined &&
       currentBranch.getParentFromMeta() != undefined // dont put up pr for a base branch like "main"
     ) {

--- a/src/commands/validate/index.ts
+++ b/src/commands/validate/index.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import yargs from "yargs";
 import { log } from "../../lib/log";
+import { logWarn } from "../../lib/utils";
 import Branch from "../../wrapper-classes/branch";
 import AbstractCommand from "../abstract_command";
 
@@ -17,7 +18,13 @@ type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 export default class ValidateCommand extends AbstractCommand<typeof args> {
   static args = args;
   public async _execute(argv: argsT): Promise<void> {
-    await validateBranch(Branch.getCurrentBranch(), argv);
+    const branch = Branch.getCurrentBranch();
+    if (branch === null) {
+      logWarn("Not currently on a branch; no stack to validate.");
+      return;
+    }
+
+    await validateBranch(branch, argv);
     log(`Current stack is valid`, argv);
   }
 }

--- a/src/lib/utils/splog.ts
+++ b/src/lib/utils/splog.ts
@@ -4,7 +4,7 @@ export function logError(msg: string): void {
   console.log(chalk.redBright(`ERROR: ${msg}`));
 }
 
-export function logErrorAndExit(msg: string): void {
+export function logErrorAndExit(msg: string): never {
   logError(msg);
   process.exit(1);
 }

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -1,4 +1,5 @@
 import { execSync } from "child_process";
+import { gpExecSync } from "../lib/utils";
 import Commit from "./commit";
 
 type TBranchDesc = {
@@ -181,10 +182,19 @@ export default class Branch {
     return new Branch(name);
   }
 
-  static getCurrentBranch(): Branch {
-    return new Branch(
-      execSync(`git rev-parse --abbrev-ref HEAD`).toString().trim()
-    );
+  static getCurrentBranch(): Branch | null {
+    const name = gpExecSync(
+      {
+        command: `git rev-parse --abbrev-ref HEAD`,
+      },
+      (e) => {
+        return Buffer.alloc(0);
+      }
+    )
+      .toString()
+      .trim();
+
+    return name.length > 0 ? new Branch(name) : null;
   }
 
   static async getAllBranchesWithoutParents(): Promise<Branch[]> {


### PR DESCRIPTION
If there's no current checked out branch, rather than crashing noisily, catch this and handle it properly.

We do this by converting the `execSync` to find the current branch in a `gpExecSync` and then handle it locally at each callsite, surfacing the appropriate error.