### PR TITLE
[Submit] Store returned PR info in branch metadata

### DIFF
--- a/src/commands/original-commands/submit/index.ts
+++ b/src/commands/original-commands/submit/index.ts
@@ -254,13 +254,12 @@ export default class SubmitCommand extends AbstractCommand<typeof args> {
       typeof graphiteCLIRoutes.submitPullRequests.response
     >["prs"]
   ): void {
-    prs.forEach((pr) => {
+    prs.forEach(async (pr) => {
       if (pr.status === "updated" || pr.status === "created") {
-        Branch.branchWithName(pr.head).then((branch) => {
-          branch.setPRInfo({
-            number: pr.prNumber,
-            url: pr.prURL,
-          });
+        const branch = await Branch.branchWithName(pr.head);
+        branch.setPRInfo({
+          number: pr.prNumber,
+          url: pr.prURL,
         });
       }
     });

--- a/src/commands/original-commands/submit/index.ts
+++ b/src/commands/original-commands/submit/index.ts
@@ -83,6 +83,7 @@ export default class SubmitCommand extends AbstractCommand<typeof args> {
     }
 
     this.printSubmittedPRInfo(submittedPRInfo.prs);
+    this.saveBranchPRInfo(submittedPRInfo.prs);
   }
 
   getCLIAuthToken(): string {
@@ -168,15 +169,26 @@ export default class SubmitCommand extends AbstractCommand<typeof args> {
       // a PR for has a valid parent.
       const parentBranchName = branch.getParentFromMeta()!.name;
 
-      branchPRInfo.push({
-        action: "create",
-        head: branch.name,
-        base: parentBranchName,
-        // Default placeholder title.
-        // TODO (nicholasyan): improve this by using the commit message if the
-        // branch only has 1 commit.
-        title: `Merge ${branch.name} into ${parentBranchName}`,
-      });
+      const prInfo = branch.getPRInfo();
+
+      if (prInfo) {
+        branchPRInfo.push({
+          action: "update",
+          head: branch.name,
+          base: parentBranchName,
+          prNumber: prInfo.number,
+        });
+      } else {
+        branchPRInfo.push({
+          action: "create",
+          head: branch.name,
+          base: parentBranchName,
+          // Default placeholder title.
+          // TODO (nicholasyan): improve this by using the commit message if the
+          // branch only has 1 commit.
+          title: `Merge ${branch.name} into ${parentBranchName}`,
+        });
+      }
     });
 
     try {
@@ -234,6 +246,23 @@ export default class SubmitCommand extends AbstractCommand<typeof args> {
       }
 
       logNewline();
+    });
+  }
+
+  saveBranchPRInfo(
+    prs: t.UnwrapSchemaMap<
+      typeof graphiteCLIRoutes.submitPullRequests.response
+    >["prs"]
+  ): void {
+    prs.forEach((pr) => {
+      if (pr.status === "updated" || pr.status === "created") {
+        Branch.branchWithName(pr.head).then((branch) => {
+          branch.setPRInfo({
+            number: pr.prNumber,
+            url: pr.prURL,
+          });
+        });
+      }
     });
   }
 

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -2,18 +2,13 @@ import { execSync } from "child_process";
 import { gpExecSync, logErrorAndExit } from "../lib/utils";
 import Commit from "./commit";
 
-<<<<<<< HEAD
 type TMeta = {
   parentBranchName?: string;
   prevRef?: string;
-=======
-type TBranchDesc = {
-  parentBranchName?: string;
   prInfo?: {
     number: number;
     url: string;
   };
->>>>>>> 456f081 ([Submit] Store returned PR info in branch metadata)
 };
 
 export const MAX_COMMITS_TO_TRAVERSE_FOR_NEXT_OR_PREV = 50;
@@ -328,10 +323,9 @@ export default class Branch {
   }
 
   public setPRInfo(prInfo: { number: number; url: string }): void {
-    this.writeMeta({
-      ...this.getMeta(),
-      prInfo: prInfo,
-    });
+    const meta: TMeta = this.getMeta() || {};
+    meta.prInfo = prInfo;
+    this.writeMeta(meta);
   }
 
   public getPRInfo(): { number: number; url: string } | undefined {

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -2,9 +2,18 @@ import { execSync } from "child_process";
 import { gpExecSync, logErrorAndExit } from "../lib/utils";
 import Commit from "./commit";
 
+<<<<<<< HEAD
 type TMeta = {
   parentBranchName?: string;
   prevRef?: string;
+=======
+type TBranchDesc = {
+  parentBranchName?: string;
+  prInfo?: {
+    number: number;
+    url: string;
+  };
+>>>>>>> 456f081 ([Submit] Store returned PR info in branch metadata)
 };
 
 export const MAX_COMMITS_TO_TRAVERSE_FOR_NEXT_OR_PREV = 50;
@@ -316,5 +325,16 @@ export default class Branch {
     return Array.from(
       traverseGitTreeFromCommitUntilBranch(headSha, gitTree, branchList, 0)
     ).map((name) => new Branch(name));
+  }
+
+  public setPRInfo(prInfo: { number: number; url: string }): void {
+    this.writeMeta({
+      ...this.getMeta(),
+      prInfo: prInfo,
+    });
+  }
+
+  public getPRInfo(): { number: number; url: string } | undefined {
+    return this.getMeta()?.prInfo;
   }
 }


### PR DESCRIPTION
Allows us to later:
* decide whether we're creating or updating a PR
* show smart log without needing to hit the server