### PR TITLE
[Repo Config] Add Repo Config Commands

### DIFF
--- a/src/actions/onto.ts
+++ b/src/actions/onto.ts
@@ -1,14 +1,16 @@
 import chalk from "chalk";
+import {
+  CURRENT_REPO_CONFIG_PATH,
+  trunkBranches,
+} from "../actions/repo_config";
 import { validate } from "../actions/validate";
 import PrintStacksCommand from "../commands/original-commands/print-stacks";
 import { log } from "../lib/log";
 import {
   checkoutBranch,
-  CURRENT_REPO_CONFIG_PATH,
   gpExecSync,
   logErrorAndExit,
   rebaseInProgress,
-  trunkBranches,
   uncommittedChanges,
 } from "../lib/utils";
 import Branch from "../wrapper-classes/branch";

--- a/src/actions/repo_config.ts
+++ b/src/actions/repo_config.ts
@@ -1,0 +1,134 @@
+import chalk from "chalk";
+import fs from "fs-extra";
+import path from "path";
+import { gpExecSync, logErrorAndExit } from "../lib/utils";
+
+const CONFIG_NAME = ".graphite_repo_config";
+type RepoConfigT = {
+  owner?: string;
+  name?: string;
+  trunkBranches?: string[];
+};
+
+export const CURRENT_REPO_CONFIG_PATH: string = (() => {
+  const repoRootPath = gpExecSync(
+    {
+      command: `git rev-parse --show-toplevel`,
+    },
+    (e) => {
+      return Buffer.alloc(0);
+    }
+  )
+    .toString()
+    .trim();
+
+  if (!repoRootPath || repoRootPath.length === 0) {
+    logErrorAndExit("No .git repository found.");
+  }
+
+  return path.join(repoRootPath, CONFIG_NAME);
+})();
+
+let repoConfig: RepoConfigT = {};
+if (fs.existsSync(CURRENT_REPO_CONFIG_PATH)) {
+  const repoConfigRaw = fs.readFileSync(CURRENT_REPO_CONFIG_PATH);
+  try {
+    repoConfig = JSON.parse(repoConfigRaw.toString().trim()) as RepoConfigT;
+  } catch (e) {
+    console.log(chalk.yellow(`Warning: Malformed ${CURRENT_REPO_CONFIG_PATH}`));
+  }
+}
+
+export function getRepoOwner(): string {
+  if (repoConfig.owner) {
+    return repoConfig.owner;
+  }
+
+  const inferredInfo = inferRepoGitHubInfo();
+  if (inferredInfo?.repoOwner) {
+    return inferredInfo.repoOwner;
+  }
+
+  logErrorAndExit(
+    "Could not determine the owner of this repo (e.g. 'screenplaydev' in the repo 'screenplaydev/graphite-cli'). Please run `gp repo-config owner --set <owner>` to manually set the repo owner."
+  );
+}
+
+export function setRepoOwner(owner: string): void {
+  repoConfig.owner = owner;
+  persistRepoConfig(repoConfig);
+}
+
+export function getRepoName(): string {
+  if (repoConfig.name) {
+    return repoConfig.name;
+  }
+
+  const inferredInfo = inferRepoGitHubInfo();
+  if (inferredInfo?.repoName) {
+    return inferredInfo.repoName;
+  }
+
+  logErrorAndExit(
+    "Could not determine the name of this repo (e.g. 'graphite-cli' in the repo 'screenplaydev/graphite-cli'). Please run `gp repo-config name --set <owner>` to manually set the repo name."
+  );
+}
+
+export function setRepoName(name: string): void {
+  repoConfig.name = name;
+  persistRepoConfig(repoConfig);
+}
+
+function persistRepoConfig(config: RepoConfigT): void {
+  fs.writeFileSync(CURRENT_REPO_CONFIG_PATH, JSON.stringify(config));
+}
+
+export const trunkBranches: string[] | undefined = repoConfig.trunkBranches;
+
+function inferRepoGitHubInfo(): {
+  repoOwner: string;
+  repoName: string;
+} | null {
+  // This assumes that the remote to use is named 'origin' and that the remote
+  // to fetch from is the same as the remote to push to. If a user runs into
+  // an issue where any of these invariants are not true, they can manually
+  // edit the repo config file to overrule what our CLI tries to intelligently
+  // infer.
+  const url = gpExecSync(
+    {
+      command: `git config --get remote.origin.url`,
+    },
+    (_) => {
+      return Buffer.alloc(0);
+    }
+  )
+    .toString()
+    .trim();
+  if (!url || url.length === 0) {
+    return null;
+  }
+
+  let regex = undefined;
+  if (url.startsWith("git@github.com")) {
+    regex = /git@github.com:([^/]+)\/(.+)?.git/;
+  } else if (url.startsWith("https://")) {
+    regex = /https:\/\/github.com\/([^/]+)\/(.+)?.git/;
+  } else {
+    return null;
+  }
+
+  // e.g. in screenplaydev/graphite-cli we're trying to get the owner
+  // ('screenplaydev') and the repo name ('graphite-cli')
+  const matches = regex.exec(url);
+  const owner = matches?.[1];
+  const name = matches?.[2];
+
+  if (owner === undefined || name === undefined) {
+    return null;
+  }
+
+  return {
+    repoOwner: owner,
+    repoName: name,
+  };
+}

--- a/src/commands/repo-config-commands/repo_name.ts
+++ b/src/commands/repo-config-commands/repo_name.ts
@@ -1,0 +1,29 @@
+import yargs from "yargs";
+import { getRepoName, setRepoName } from "../../actions/repo_config";
+import { profiledHandler } from "../../lib/telemetry";
+import { logInfo } from "../../lib/utils";
+
+const args = {
+  set: {
+    demandOption: false,
+    default: false,
+    type: "string",
+    alias: "s",
+  },
+} as const;
+
+type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
+
+export const command = "name";
+export const description =
+  "Graphite's conception of the current repo's name. e.g. in 'screenplaydev/graphite-cli', this is 'graphite-cli'.";
+export const builder = args;
+export const handler = async (argv: argsT): Promise<void> => {
+  return profiledHandler(command, async () => {
+    if (argv.set) {
+      setRepoName(argv.set);
+    } else {
+      logInfo(getRepoName());
+    }
+  });
+};

--- a/src/commands/repo-config-commands/repo_name.ts
+++ b/src/commands/repo-config-commands/repo_name.ts
@@ -9,6 +9,8 @@ const args = {
     default: false,
     type: "string",
     alias: "s",
+    describe:
+      "Override the value of the repo's name in the Graphite config. This is expected to match the name of the repo on GitHub and should only be set in cases where Graphite is incorrectly inferring the name.",
   },
 } as const;
 

--- a/src/commands/repo-config-commands/repo_owner.ts
+++ b/src/commands/repo-config-commands/repo_owner.ts
@@ -9,6 +9,8 @@ const args = {
     default: false,
     type: "string",
     alias: "s",
+    describe:
+      "Override the value of the repo owner's name in the Graphite config. This is expected to match the name of the repo owner on GitHub and should only be set in cases where Graphite is incorrectly inferring the name.",
   },
 } as const;
 

--- a/src/commands/repo-config-commands/repo_owner.ts
+++ b/src/commands/repo-config-commands/repo_owner.ts
@@ -1,0 +1,29 @@
+import yargs from "yargs";
+import { getRepoOwner, setRepoOwner } from "../../actions/repo_config";
+import { profiledHandler } from "../../lib/telemetry";
+import { logInfo } from "../../lib/utils";
+
+const args = {
+  set: {
+    demandOption: false,
+    default: false,
+    type: "string",
+    alias: "s",
+  },
+} as const;
+
+type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
+
+export const command = "owner";
+export const description =
+  "Graphite's conception of the current repo's owner. e.g. in 'screenplaydev/graphite-cli', this is 'screenplaydev'.";
+export const builder = args;
+export const handler = async (argv: argsT): Promise<void> => {
+  return profiledHandler(command, async () => {
+    if (argv.set) {
+      setRepoOwner(argv.set);
+    } else {
+      logInfo(getRepoOwner());
+    }
+  });
+};

--- a/src/commands/repo_config.ts
+++ b/src/commands/repo_config.ts
@@ -1,0 +1,14 @@
+import { Argv } from "yargs";
+
+export const command = "repo-config <command>";
+export const desc =
+  "Read or write Graphite's configuration settings for the current repo.";
+
+export const builder = function (yargs: Argv): Argv {
+  return yargs
+    .commandDir("repo-config-commands", {
+      extensions: ["js"],
+    })
+    .strict()
+    .demandCommand();
+};

--- a/src/lib/utils/config.ts
+++ b/src/lib/utils/config.ts
@@ -2,8 +2,6 @@ import chalk from "chalk";
 import fs from "fs-extra";
 import os from "os";
 import path from "path";
-import { gpExecSync } from "./exec_sync";
-import { logErrorAndExit } from "./splog";
 
 const CONFIG_NAME = ".graphite_repo_config";
 const USER_CONFIG_PATH = path.join(os.homedir(), CONFIG_NAME);
@@ -11,30 +9,6 @@ type UserConfigT = {
   branchPrefix?: string;
   authToken?: string;
 };
-type RepoConfigT = {
-  trunkBranches?: string[];
-  owner?: string;
-  repoName?: string;
-};
-
-export const CURRENT_REPO_CONFIG_PATH: string = (() => {
-  const repoRootPath = gpExecSync(
-    {
-      command: `git rev-parse --show-toplevel`,
-    },
-    (e) => {
-      return Buffer.alloc(0);
-    }
-  )
-    .toString()
-    .trim();
-
-  if (!repoRootPath || repoRootPath.length === 0) {
-    logErrorAndExit("No .git repository found.");
-  }
-
-  return path.join(repoRootPath, CONFIG_NAME);
-})();
 
 export function makeId(length: number): string {
   let result = "";
@@ -69,15 +43,3 @@ function setUserConfig(config: UserConfigT): void {
   fs.writeFileSync(USER_CONFIG_PATH, JSON.stringify(config));
   userConfig = config;
 }
-
-export let repoConfig: RepoConfigT = {};
-if (fs.existsSync(CURRENT_REPO_CONFIG_PATH)) {
-  const repoConfigRaw = fs.readFileSync(CURRENT_REPO_CONFIG_PATH);
-  try {
-    repoConfig = JSON.parse(repoConfigRaw.toString().trim()) as RepoConfigT;
-  } catch (e) {
-    console.log(chalk.yellow(`Warning: Malformed ${CURRENT_REPO_CONFIG_PATH}`));
-  }
-}
-
-export const trunkBranches: string[] | undefined = repoConfig.trunkBranches;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,12 +1,5 @@
 import { checkoutBranch } from "./checkout_branch";
-import {
-  CURRENT_REPO_CONFIG_PATH,
-  makeId,
-  repoConfig,
-  setUserAuthToken,
-  trunkBranches,
-  userConfig,
-} from "./config";
+import { makeId, setUserAuthToken, userConfig } from "./config";
 import { detectStagedChanges } from "./detect_staged_changes";
 import { gpExecSync } from "./exec_sync";
 import { rebaseInProgress } from "./rebase_in_progress";
@@ -22,12 +15,9 @@ import {
 import { uncommittedChanges } from "./uncommitted_changes";
 
 export {
-  CURRENT_REPO_CONFIG_PATH,
   makeId,
   userConfig,
   setUserAuthToken,
-  repoConfig,
-  trunkBranches,
   gpExecSync,
   logError,
   logErrorAndExit,


### PR DESCRIPTION
Adding commands to set/get fields in our repo config and then migrating our existing logic to use this same internal logic.

```
> lgp repo-config name
dummy
> lgp repo-config owner
nicholasyan
```

We can expand this next by making the trunk branches and the remote name (e.g. 'origin') customizable as well.

The payoff here is that creating a local repo config is now an opt-in action, avoiding the uncommitted changes issues we were seeing this morning. We always infer the fields unless the user chooses to set an override via `lgp repo-config <field> --set`.

This PR both adds + migrates things so it might be easier to review by reviewing each commit. (Each commit builds on its own.)

Also TODO here — tests.