### PR TITLE
Create Single Type for Scope Arguments

### DIFF
--- a/src/actions/scope.ts
+++ b/src/actions/scope.ts
@@ -1,0 +1,1 @@
+export type TScope = "UPSTACK" | "DOWNSTACK" | "FULLSTACK";

--- a/src/actions/submit.ts
+++ b/src/actions/submit.ts
@@ -17,12 +17,15 @@ import {
 } from "../lib/utils";
 import Branch from "../wrapper-classes/branch";
 import { getRepoName, getRepoOwner } from "./repo_config";
+import { TScope } from "./scope";
 import { validate } from "./validate";
 
 type TSubmittedPRInfo = t.UnwrapSchemaMap<
   typeof graphiteCLIRoutes.submitPullRequests.response
 >;
+
 export async function submitAction(
+  scope: TScope,
   args: Record<string, unknown>
 ): Promise<void> {
   const cliAuthToken = getCLIAuthToken();
@@ -30,7 +33,7 @@ export async function submitAction(
   const repoOwner = getRepoOwner();
 
   try {
-    await validate("FULLSTACK", true);
+    await validate(scope, true);
   } catch {
     await new PrintStacksCommand().executeUnprofiled({});
     throw new Error(`Validation failed before submitting.`);

--- a/src/actions/validate.ts
+++ b/src/actions/validate.ts
@@ -2,9 +2,9 @@ import chalk from "chalk";
 import { log } from "../lib/log";
 import { logErrorAndExit } from "../lib/utils";
 import Branch from "../wrapper-classes/branch";
+import { TScope } from "./scope";
 
-type scopeT = "UPSTACK" | "DOWNSTACK" | "FULLSTACK";
-export async function validate(scope: scopeT, silent: boolean): Promise<void> {
+export async function validate(scope: TScope, silent: boolean): Promise<void> {
   const branch = Branch.getCurrentBranch();
   if (branch === null) {
     logErrorAndExit("Not currently on a branch; no stack to validate.");

--- a/src/commands/stack-commands/submit.ts
+++ b/src/commands/stack-commands/submit.ts
@@ -12,6 +12,6 @@ export const builder = args;
 
 export const handler = async (argv: argsT): Promise<void> => {
   await profiledHandler(command, async () => {
-    await submitAction({});
+    await submitAction("FULLSTACK", {});
   });
 };


### PR DESCRIPTION
Sharing a type for the scope arg so that we can seamlessly pass in the case where a command calls into a sub-command (e.g. submit calling validate).