### PR TITLE
Check all parents for trunk in fullStackFromBranch

### DIFF
--- a/src/wrapper-classes/git_stack_builder.ts
+++ b/src/wrapper-classes/git_stack_builder.ts
@@ -7,9 +7,12 @@ export class GitStackBuilder extends AbstractStackBuilder {
     const stack = this.upstackInclusiveFromBranchWithoutParents(base);
 
     const parents = base.getParentsFromGit();
+    const parentsIncludeTrunk = parents
+      .map((parent) => parent.name)
+      .includes(getTrunk().name);
 
-    // If the parent isnt trunk, just return.
-    if (parents[0]?.name !== getTrunk().name) {
+    // If the parents don't include trunk, just return.
+    if (!parentsIncludeTrunk) {
       return stack;
     }
 


### PR DESCRIPTION
A branch may have multiple parents, so rather than just check whether the first one is trunk, check them all.

Along with the prior PR, this fixes the multiple-branches-same-commit issue that we ran into this morning.