### PR TITLE
Fix branchListFromShowRefOutput to support multiple branches with same hash

### DIFF
--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -29,16 +29,21 @@ function gitTreeFromRevListOutput(output: string): Record<string, string[]> {
   return ret;
 }
 
-function branchListFromShowRefOutput(output: string): Record<string, string> {
-  const ret: Record<string, string> = {};
+function branchListFromShowRefOutput(output: string): Record<string, string[]> {
+  const ret: Record<string, string[]> = {};
   const ignorebranches = repoConfig.getIgnoreBranches();
 
   for (const line of output.split("\n")) {
     if (line.length > 0) {
       const parts = line.split(" ");
       const branchName = parts[1].slice("refs/heads/".length);
+      const branchRef = parts[0];
       if (!ignorebranches.includes(branchName)) {
-        ret[parts[0]] = branchName;
+        if (branchRef in ret) {
+          ret[branchRef].push(branchName);
+        } else {
+          ret[branchRef] = [branchName];
+        }
       }
     }
   }
@@ -49,12 +54,12 @@ function branchListFromShowRefOutput(output: string): Record<string, string> {
 function traverseGitTreeFromCommitUntilBranch(
   commit: string,
   gitTree: Record<string, string[]>,
-  branchList: Record<string, string>,
+  branchList: Record<string, string[]>,
   n: number
 ): Set<string> {
   // Skip the first iteration b/c that is the CURRENT branch
   if (n > 0 && commit in branchList) {
-    return new Set([branchList[commit]]);
+    return new Set(branchList[commit]);
   }
 
   // Limit the seach


### PR DESCRIPTION
Right now `branchListFromShowRefOutput` stores hashes to branches in a record of string => string. This means that if multiple branch tips point to the same hash 1) whichever branch appears last in the ref output is saved as the definitive branch for that hash 2) all of the previous branches (which also point to that hash) are dropped.

This PR fixes the issue.