### PR TITLE
Fix error telemetry

### DIFF
--- a/src/lib/telemetry/profile.ts
+++ b/src/lib/telemetry/profile.ts
@@ -84,7 +84,11 @@ export async function profile(
     postTelemetryInBackground({
       commandName: parsedArgs.command,
       durationMiliSeconds: end - start,
-      err,
+      err: {
+        errName: err.name,
+        errMessage: err.message,
+        errStack: err.stack || "",
+      },
     });
     // eslint-disable-next-line no-restricted-syntax
     process.exit(1);


### PR DESCRIPTION
Noticed this today when trying to track down telemetry for an issue — there's a type mismatch in our error telemetry which is causing us to lose traces. This PR fixes it.

Verified by causing error locally + watching local server.