### PR TITLE
[Log] Surface errors

### DIFF
--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -36,12 +36,8 @@ export const handler = async (argv: argsT): Promise<void> => {
       }
     } else {
       // Use our custom logging of branches and stacks:
-      try {
-        printTrunkLog();
-        await printStacksBehindTrunk();
-      } catch (e) {
-        console.log(e);
-      }
+      printTrunkLog();
+      await printStacksBehindTrunk();
     }
   });
 };


### PR DESCRIPTION
Now that Greg has introduced a proper error boundary, we *should* be throwing errors so that our telemetry captures it — rather than silencing them.