### PR TITLE
Fix mystery hash

### DIFF
--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -598,12 +598,8 @@ export default class Branch {
 
     const matchingBranches = matchingBranchesRaw
       .split("\n")
-      .map((refName) => {
-        return refName.replace("refs/heads/", "");
-      })
-      .map((name) => {
-        return new Branch(name);
-      });
+      .map((refName) => refName.replace("refs/heads/", ""))
+      .map((name) => new Branch(name));
     return matchingBranches;
   }
 }

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -265,8 +265,9 @@ export default class Branch {
         command: `git show-ref refs/heads/${this.name} -s`,
       },
       (_) => {
-        // just soft-fail if we can't find the commits
-        return Buffer.alloc(0);
+        throw new ExitFailedError(
+          `Could not find ref refs/heads/${this.name}.`
+        );
       }
     )
       .toString()
@@ -580,19 +581,29 @@ export default class Branch {
   }
 
   public branchesWithSameCommit(): Branch[] {
-    const curBranchSha = execSync(
-      `git show-ref --heads | grep refs/heads/${this.name} -s | awk '{print $1}'`
+    const matchingBranchesRaw = execSync(
+      `git show-ref --heads | grep ${this.ref()} | grep -v "refs/heads/${
+        this.name
+      }" | awk '{print $2}'`
     )
       .toString()
       .trim();
-    const matchingBranches = execSync(
-      `git show-ref --heads | grep ${curBranchSha} | grep -v "refs/heads/${this.name}" | awk '{print $2}'`
-    )
-      .toString()
-      .trim()
+
+    // We want to check the length before we split because ''.split("\n")
+    // counterintuitively returns [ '' ] (an array with 1 entry as the empty
+    // string).
+    if (matchingBranchesRaw.length === 0) {
+      return [];
+    }
+
+    const matchingBranches = matchingBranchesRaw
       .split("\n")
-      .map((refName) => refName.replace("refs/heads/", ""))
-      .map((name) => new Branch(name));
+      .map((refName) => {
+        return refName.replace("refs/heads/", "");
+      })
+      .map((name) => {
+        return new Branch(name);
+      });
     return matchingBranches;
   }
 }


### PR DESCRIPTION
A few misc fixes:

Fix 1:
```
`git show-ref --heads | grep refs/heads/${this.name} -s | awk '{print $1}'`
```
* in `branchesWithSameCommit` we were using this command to find the ref for the given branch
* however, if the current branch was also a prefix for another branch's name (e.g. branch-a and branch-a1), this command would return multiple SHAs
* this would later get piped onto other commands which were expecting just 1 SHA
* fix: just re-use the existing `ref()` method as the source of truth (which correctly matches exactly the branch name)

Fix 2:
* in the case where no SHA was found for branches with the same commit, `...toString().trim().split("\n")` still returns an array `[ '' ]` with just the empty string
* this meant we were creating a bunch of branches with no name
* fix: we now check the string length before doing the split