### PR TITLE
[Log] Hide remote branches in log -c

### DIFF
--- a/src/commands/log-commands/long.ts
+++ b/src/commands/log-commands/long.ts
@@ -15,7 +15,7 @@ export const handler = async (argv: argsT): Promise<void> => {
     // If this flag is passed, print the old logging style:
     try {
       execSync(
-        `git log --graph --abbrev-commit --decorate --format=format:'%C(bold blue)%h%C(reset) - %C(bold green)(%ar)%C(reset) %C(white)%s%C(reset) %C(dim white)- %an%C(reset)%C(auto)%d%C(reset)' --all`,
+        `git log --graph --abbrev-commit --decorate --format=format:'%C(bold blue)%h%C(reset) - %C(bold green)(%ar)%C(reset) %C(white)%s%C(reset) %C(dim white)- %an%C(reset)%C(auto)%d%C(reset)' --branches`,
         { stdio: "inherit" }
       );
     } catch (e) {


### PR DESCRIPTION
Adding `--branches` here instead of `--all` limits the search to show local branches (i.e. `refs/heads`) rather than everything in the `refs` folder.