### PR TITLE
fix(log_short): resolve complex repo crash state

### DIFF
--- a/src/actions/stacks.ts
+++ b/src/actions/stacks.ts
@@ -103,6 +103,9 @@ function computeLineage(args: {
       status: branch.getParentsFromGit().length > 0 ? "NEEDS_REGEN" : "TRACKED",
     });
   } else {
+    if (!children[parent.name]) {
+      children[parent.name] = [];
+    }
     children[parent.name].push({
       branch,
       status: branch.getParentsFromGit().some((gitParent) => {


### PR DESCRIPTION
Recreated in a test case a crash noticed by a user: https://screenplaydev.slack.com/archives/C028QNXTNBF/p1629219853474000?thread_ts=1629219370.473300&cid=C028QNXTNBF 

Then fixed the bug