### PR TITLE
[Repo Config] Allow max branch length to be configured

### DIFF
--- a/src/commands/repo-commands/max_branch_length.ts
+++ b/src/commands/repo-commands/max_branch_length.ts
@@ -1,0 +1,31 @@
+import yargs from "yargs";
+import { repoConfig } from "../../lib/config";
+import { profile } from "../../lib/telemetry";
+import { logInfo } from "../../lib/utils";
+
+const args = {
+  set: {
+    demandOption: false,
+    default: false,
+    type: "number",
+    alias: "s",
+    describe:
+      "Override the max number of commits on a branch Graphite will track.",
+  },
+} as const;
+
+type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
+
+export const command = "max-branch-length";
+export const description =
+  "Graphite will track up to this many commits on a branch. e.g. If this is set to 50, Graphite can track branches up to 50 commits long. Increasing this setting may result in slower performance for Graphite.";
+export const builder = args;
+export const handler = async (argv: argsT): Promise<void> => {
+  return profile(argv, async () => {
+    if (argv.set) {
+      repoConfig.setMaxBranchLength(argv.set);
+    } else {
+      logInfo(`${repoConfig.getMaxBranchLength().toString()} commits`);
+    }
+  });
+};

--- a/src/lib/config/repo_config.ts
+++ b/src/lib/config/repo_config.ts
@@ -41,6 +41,7 @@ type RepoConfigT = {
   };
   maxStacksShownBehindTrunk?: number;
   maxDaysShownBehindTrunk?: number;
+  maxBranchLength?: number;
 };
 
 class RepoConfig {
@@ -160,6 +161,15 @@ class RepoConfig {
     }
 
     this._data.logSettings = undefined;
+    this.save();
+  }
+
+  public getMaxBranchLength(): number {
+    return this._data.maxBranchLength ?? 50;
+  }
+
+  public setMaxBranchLength(numCommits: number) {
+    this._data.maxBranchLength = numCommits;
     this.save();
   }
 }


### PR DESCRIPTION
**Context**

Earlier today, we ran into an issue where a branch was legitimately longer than our max cap right now: [context here](https://screenplaydev.slack.com/archives/C010GNVCUU9/p1629227572023100).

**This PR**

This PR adds a couple of things to fix this:
* Our max branch length is now stored in our repo config.
* We add a command to configure this max.
* We add a warning when we short-circuit a search due to the max.
  * This is normally hidden since we normally silence the output of `gt stack validate`, but if we ever debug with a user and they run it, they'll be able to see the output.

Here it is in action:

<img width="977" alt="image" src="https://user-images.githubusercontent.com/9063972/129799089-bb05300c-6ef6-401c-a209-bc2b5620f09e.png">
