### PR TITLE
[Debug] Introduce 'debug' flag + add debug output for short-circuited parent/child searches

### DIFF
--- a/src/lib/config/exec_state_config.ts
+++ b/src/lib/config/exec_state_config.ts
@@ -1,0 +1,26 @@
+type ExecStateConfigT = {
+  outputDebugLogs?: boolean;
+};
+
+/**
+ * An in-memory object that configures global settings for the current
+ * invocation of the Graphite CLI.
+ */
+class ExecStateConfig {
+  _data: ExecStateConfigT;
+
+  constructor() {
+    this._data = {};
+  }
+
+  setOutputDebugLogs(outputDebugLogs: boolean): void {
+    this._data.outputDebugLogs = outputDebugLogs;
+  }
+
+  outputDebugLogs(): boolean {
+    return this._data.outputDebugLogs ?? false;
+  }
+}
+
+const execStateConfig = new ExecStateConfig();
+export default execStateConfig;

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -1,3 +1,4 @@
+import execStateConfig from "./exec_state_config";
 import messageConfig, {
   readMessageConfigForTestingOnly,
 } from "./message_config";
@@ -9,4 +10,5 @@ export {
   userConfig,
   repoConfig,
   readMessageConfigForTestingOnly,
+  execStateConfig,
 };

--- a/src/lib/global-arguments/index.ts
+++ b/src/lib/global-arguments/index.ts
@@ -1,4 +1,5 @@
 import yargs from "yargs";
+import { execStateConfig } from "../config";
 
 const globalArgumentsOptions = {
   interactive: {
@@ -9,6 +10,7 @@ const globalArgumentsOptions = {
   },
   quiet: { alias: "q", default: false, type: "boolean", demandOption: false },
   verify: { default: true, type: "boolean", demandOption: false },
+  debug: { default: false, type: "boolean", demandOption: false },
 } as const;
 
 type argsT = yargs.Arguments<
@@ -19,6 +21,7 @@ function processGlobalArgumentsMiddleware(argv: argsT): void {
   globalArgs.quiet = argv.quiet;
   globalArgs.noVerify = !argv.verify;
   globalArgs.interactive = argv.interactive;
+  execStateConfig.setOutputDebugLogs(argv.debug);
 }
 
 const globalArgs = { quiet: false, noVerify: false, interactive: true };

--- a/src/lib/utils/splog.ts
+++ b/src/lib/utils/splog.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import { execStateConfig } from "../config";
 import { globalArgs } from "../global-arguments";
 
 export function logError(msg: string): void {
@@ -18,6 +19,12 @@ export function logInfo(msg: string): void {
 export function logSuccess(msg: string): void {
   if (!globalArgs.quiet) {
     console.log(chalk.green(`${msg}`));
+  }
+}
+
+export function logDebug(msg: string): void {
+  if (execStateConfig.outputDebugLogs()) {
+    console.log(msg);
   }
 }
 

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -1,8 +1,9 @@
+import chalk from "chalk";
 import { execSync } from "child_process";
-import { repoConfig } from "../lib/config";
+import { execStateConfig, repoConfig } from "../lib/config";
 import { ExitFailedError } from "../lib/errors";
 import { tracer } from "../lib/telemetry";
-import { getCommitterDate, getTrunk, gpExecSync, logWarn } from "../lib/utils";
+import { getCommitterDate, getTrunk, gpExecSync } from "../lib/utils";
 import Commit from "./commit";
 
 type TMeta = {
@@ -109,48 +110,57 @@ function traverseGitTreeFromCommitUntilBranch(
   commit: string,
   gitTree: Record<string, string[]>,
   branchList: Record<string, string[]>,
-  n: number,
-  debugInfo: {
-    branchName: string;
-    direction: "CHILDREN" | "PARENTS";
-  }
-): Set<string> {
+  n: number
+): {
+  branches: Set<string>;
+  shortCircuitedDueToMaxDepth?: boolean;
+} {
   // Skip the first iteration b/c that is the CURRENT branch
   if (n > 0 && commit in branchList) {
-    return new Set(branchList[commit]);
+    return {
+      branches: new Set(branchList[commit]),
+    };
   }
 
   // Limit the seach
   const maxBranchLength = repoConfig.getMaxBranchLength();
   if (n > maxBranchLength) {
-    const branchName = debugInfo.branchName;
-    const searchItems = debugInfo.direction.toLowerCase();
-    logWarn(
-      `Searched ${maxBranchLength} commits from the tip of ${branchName} but could not find ${branchName}'s ${searchItems}. If this is correct (i.e. ${branchName}'s ${searchItems} are more than ${maxBranchLength} commits away from ${branchName}'s branch tip), please increase Graphite's max branch length to search via \`gt repo max-branch-length\`.`
-    );
-    return new Set();
+    return {
+      branches: new Set(),
+      shortCircuitedDueToMaxDepth: true,
+    };
   }
 
   if (!gitTree[commit] || gitTree[commit].length == 0) {
-    return new Set();
+    return {
+      branches: new Set(),
+    };
   }
 
   const commitsMatchingBranches = new Set<string>();
+  let shortCircuitedDueToMaxDepth = undefined;
   for (const neighborCommit of gitTree[commit]) {
-    const discoveredMatches = traverseGitTreeFromCommitUntilBranch(
+    const results = traverseGitTreeFromCommitUntilBranch(
       neighborCommit,
       gitTree,
       branchList,
-      n + 1,
-      debugInfo
+      n + 1
     );
-    if (discoveredMatches.size !== 0) {
-      discoveredMatches.forEach((commit) => {
+
+    const branches = results.branches;
+    shortCircuitedDueToMaxDepth =
+      results.shortCircuitedDueToMaxDepth || shortCircuitedDueToMaxDepth;
+
+    if (branches.size !== 0) {
+      branches.forEach((commit) => {
         commitsMatchingBranches.add(commit);
       });
     }
   }
-  return commitsMatchingBranches;
+  return {
+    branches: commitsMatchingBranches,
+    shortCircuitedDueToMaxDepth: shortCircuitedDueToMaxDepth,
+  };
 }
 
 type TBranchFilters = {
@@ -566,18 +576,31 @@ export default class Branch {
           .toString()
           .trim();
 
-        return Array.from(
-          traverseGitTreeFromCommitUntilBranch(
-            headSha,
-            gitTree,
-            getBranchList({ useMemoizedResult: useMemoizedResults }),
-            0,
-            {
-              branchName: this.name,
-              direction: direction,
-            }
-          )
-        ).map((name) => {
+        const childrenOrParents = traverseGitTreeFromCommitUntilBranch(
+          headSha,
+          gitTree,
+          getBranchList({ useMemoizedResult: useMemoizedResults }),
+          0
+        );
+
+        if (
+          execStateConfig.outputDebugLogs() &&
+          childrenOrParents.shortCircuitedDueToMaxDepth
+        ) {
+          console.log(
+            `${chalk.magenta(
+              `Potential missing branch ${direction.toLocaleLowerCase()}:`
+            )} Short-circuited search for branch ${chalk.bold(
+              this.name
+            )}'s ${direction.toLocaleLowerCase()} due to Graphite 'max-branch-length' setting. (Your Graphite CLI is currently configured to search a max of <${repoConfig.getMaxBranchLength()}> commits away from a branch's tip.) If this is causing an incorrect result (e.g. you know that ${
+              this.name
+            } has ${direction.toLocaleLowerCase()} ${
+              repoConfig.getMaxBranchLength() + 1
+            } commits away), please adjust the setting using \`gt repo max-branch-length\`.`
+          );
+        }
+
+        return Array.from(childrenOrParents.branches).map((name) => {
           const branch = new Branch(name);
           return this.shouldUseMemoizedResults
             ? branch.useMemoizedResults()

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -1,9 +1,10 @@
 import chalk from "chalk";
 import { execSync } from "child_process";
-import { execStateConfig, repoConfig } from "../lib/config";
+import { repoConfig } from "../lib/config";
 import { ExitFailedError } from "../lib/errors";
 import { tracer } from "../lib/telemetry";
 import { getCommitterDate, getTrunk, gpExecSync } from "../lib/utils";
+import { logDebug } from "../lib/utils/splog";
 import Commit from "./commit";
 
 type TMeta = {
@@ -583,11 +584,8 @@ export default class Branch {
           0
         );
 
-        if (
-          execStateConfig.outputDebugLogs() &&
-          childrenOrParents.shortCircuitedDueToMaxDepth
-        ) {
-          console.log(
+        if (childrenOrParents.shortCircuitedDueToMaxDepth) {
+          logDebug(
             `${chalk.magenta(
               `Potential missing branch ${direction.toLocaleLowerCase()}:`
             )} Short-circuited search for branch ${chalk.bold(


### PR DESCRIPTION
This PR:
* Introduces a universal `--debug` flag for debug output.
* Adds an in-memory-only `execStateConfig` to allow us to configure various global settings (at this time just debug) during the invocation of the current CLI command.
* Leverages the above to output debug-only output when a short-circuited search for a parent/child of a branch is detected.

For `execStateConfig` I did consider just extending the pattern of using the `globalArgs` object, but I figured it'd be nice to have a separate object for:
* getters/setters
* settings that aren't set through global settings or have more complex logic than just global settings
* general modularity

Here is some sample output from this change: 

Note that I did my best to filter out duplicate warnings (only 1 warning per call of `Branch#getChildrenOrParents`) but didn't filter out beyond that. (e.g. if `Branch#getChildrenOrParents` is called multiple times on the same branch)

<img width="971" alt="image" src="https://user-images.githubusercontent.com/9063972/129813133-8dc7c695-5b9c-4c2d-88c6-b82dc8446f2a.png">

