### PR TITLE
[Submit] Add 'draft' flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/screenplaydev/screenplay-cli",
   "private": true,
   "dependencies": {
-    "@screenplaydev/graphite-cli-routes": "0.5.0",
+    "@screenplaydev/graphite-cli-routes": "0.6.0",
     "@screenplaydev/retype": "^0.2.0",
     "@screenplaydev/retyped-routes": "^0.1.0",
     "chalk": "^4.1.0",

--- a/src/commands/stack-commands/submit.ts
+++ b/src/commands/stack-commands/submit.ts
@@ -28,11 +28,13 @@ const args = {
     describe: "Creates new PRs in draft mode.",
     type: "boolean",
     default: true,
+    alias: "d",
   },
   edit: {
     describe: "Edit PR fields inline.",
     type: "boolean",
     default: true,
+    alias: "e",
   },
 } as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;

--- a/src/commands/stack-commands/submit.ts
+++ b/src/commands/stack-commands/submit.ts
@@ -1,18 +1,50 @@
 import yargs from "yargs";
 import { submitAction } from "../../actions/submit";
+import { globalArgs } from "../../lib/global-arguments";
 import { profile } from "../../lib/telemetry";
 
 export const command = "submit";
 export const description =
   "Idempotently force push all branches in the current stack to GitHub, creating or updating distinct pull requests for each.";
 
-const args = {} as const;
+/**
+ * Primary interaction patterns:
+ *
+ * # (default) allows user to edit PR fields inline and then submits stack as a draft
+ * gt stack submit
+ *
+ * # skips editing PR fields inline, submits stack as a draft
+ * gt stack submit --no-edit
+ *
+ * # allows user to edit PR fields inline, then publishes
+ * gt stack submit --no-draft
+ *
+ * # same as gt stack submit --no-edit
+ * gt stack submit --no-interactive
+ *
+ */
+const args = {
+  draft: {
+    describe: "Creates new PRs in draft mode.",
+    type: "boolean",
+    default: true,
+  },
+  edit: {
+    describe: "Edit PR fields inline.",
+    type: "boolean",
+    default: true,
+  },
+} as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 export const builder = args;
 export const aliases = ["s"];
 
 export const handler = async (argv: argsT): Promise<void> => {
   await profile(argv, async () => {
-    await submitAction("FULLSTACK");
+    await submitAction({
+      scope: "FULLSTACK",
+      editPRFieldsInline: argv.edit && globalArgs.interactive,
+      createNewPRsAsDraft: argv.draft,
+    });
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,14 +294,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@screenplaydev/graphite-cli-routes@npm:0.5.0":
-  version: 0.5.0
-  resolution: "@screenplaydev/graphite-cli-routes@npm:0.5.0"
+"@screenplaydev/graphite-cli-routes@npm:0.6.0":
+  version: 0.6.0
+  resolution: "@screenplaydev/graphite-cli-routes@npm:0.6.0"
   dependencies:
     "@screenplaydev/retype": ^0.2.0
     "@screenplaydev/retyped-routes": ^0.1.0
     "@types/node": ^14.14.37
-  checksum: 896b991455cd304fbf491cd4c10686307c26137f0234ee7762b18e495400219710da0a7d207a369fadd0b7c63b3cb41a5d29a16c0499c1ffe4c8e5833d10c954
+  checksum: 4e917bd1bb3ec347f861c34ea666475d57d387fc36f7e44bca08f2b9be1a3fd2a1567b5653f9be68db280daa265c530e54064fe18ee95326764a9f8b11e5847c
   languageName: node
   linkType: hard
 
@@ -2265,7 +2265,7 @@ fsevents@~2.3.1:
   dependencies:
     "@commitlint/cli": ^13.1.0
     "@commitlint/config-conventional": ^13.1.0
-    "@screenplaydev/graphite-cli-routes": 0.5.0
+    "@screenplaydev/graphite-cli-routes": 0.6.0
     "@screenplaydev/retype": ^0.2.0
     "@screenplaydev/retyped-routes": ^0.1.0
     "@types/chai": ^4.2.14


### PR DESCRIPTION
Supporting this ultimate functionality:

```
# (default) allows user to edit PR fields inline and then submits stack as a draft
gt stack submit 

# skips editing PR fields inline, submits stack as a draft
gt stack submit --no-edit

# allows user to edit PR fields inline, then publishes
gt stack submit --no-draft 

# same as gt stack submit --no-edit
gt stack submit --no-interactive
```

Takeaways:
* editing your PR fields inline is by default on (but can be turned off with `--no-edit`)
* submitting as a draft is by default on (but can be turned off with `--no-draft`)
* the editing and draft flags operate completely independently
