### PR TITLE
perf(git_children): optimize ref traversal

### DIFF
--- a/.CHANGELOG
+++ b/.CHANGELOG
@@ -1,4 +1,7 @@
-# 0.10.1 2020-08-17
+# 0.11.0 2020-08-18
+- Support PR templates in "stack submit" command.
+- Update "stack submit" to support interactive title and description setting.
+- Update "stack submit" to support creating draft PRs.
 - Allow max branch length to be configured (from the default of 50).
 - Fix a crash in logging that happened in a edge case involving trailing trunk branches.
 - Hide remote branches in "log long" output.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphite-cli",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "None",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
**Details:**
Loading all refs into memory breaks if there are more than 6 million commits, and is very slow in general for large repos. The solution is to fetch subsets of refs for traversing git branch parents and children. In order to do this, Im dropping memoization for now because we're only loading subsets each time, but we could always bring back an advanced for later.




**Test Plan:**
Passes existing tests. I also profiled it against three repos:
cd graphite && gt ls = 4 sec before, 3.1 sec after
cd linux && gt ls =    25 sec before, 12 sec after
cd dagser && gt ls =   11 sec before, 5.5 sec after


