### PR TITLE
ci(slow_tests): support testing public repos

### DIFF
--- a/.CHANGELOG
+++ b/.CHANGELOG
@@ -1,4 +1,7 @@
-# 0.10.1 2020-08-17
+# 0.11.0 2020-08-18
+- Support PR templates in "stack submit" command.
+- Update "stack submit" to support interactive title and description setting.
+- Update "stack submit" to support creating draft PRs.
 - Allow max branch length to be configured (from the default of 50).
 - Fix a crash in logging that happened in a edge case involving trailing trunk branches.
 - Hide remote branches in "log long" output.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphite-cli",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "None",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/utils/git_repo.ts
+++ b/src/lib/utils/git_repo.ts
@@ -5,9 +5,11 @@ import { rebaseInProgress } from "./";
 const TEXT_FILE_NAME = "test.txt";
 export default class GitRepo {
   dir: string;
-  constructor(dir: string, init = true) {
+  constructor(dir: string, opts?: { repoUrl: string }) {
     this.dir = dir;
-    if (init) {
+    if (opts?.repoUrl) {
+      execSync(`git clone ${opts.repoUrl} ${dir}`);
+    } else {
       execSync(`git init ${dir} -b main`);
     }
   }

--- a/test/lib/scenes/index.ts
+++ b/test/lib/scenes/index.ts
@@ -1,5 +1,5 @@
 import { BasicScene } from "./basic_scene";
-import { LargeScene } from "./large_scene";
+import { PublicRepoScene } from "./public_repo_scene";
 import { TrailingProdScene } from "./trailing_prod_scene";
 
 const allScenes = [
@@ -7,4 +7,4 @@ const allScenes = [
   new TrailingProdScene(),
 ];
 
-export { TrailingProdScene, BasicScene, allScenes, LargeScene };
+export { TrailingProdScene, BasicScene, allScenes, PublicRepoScene };

--- a/test/lib/scenes/public_repo_scene.ts
+++ b/test/lib/scenes/public_repo_scene.ts
@@ -4,15 +4,25 @@ import tmp from "tmp";
 import { GitRepo } from "../../../src/lib/utils";
 import { AbstractScene } from "./abstract_scene";
 
-export class LargeScene extends AbstractScene {
+export class PublicRepoScene extends AbstractScene {
+  repoUrl: string;
+  name: string;
+  timeout: number;
+
+  constructor(opts: { repoUrl: string; name: string; timeout: number }) {
+    super();
+    this.repoUrl = opts.repoUrl;
+    this.name = opts.name;
+    this.timeout = opts.timeout;
+  }
+
   public toString(): string {
-    return "LargeScene";
+    return this.name;
   }
   public setup(): void {
     this.tmpDir = tmp.dirSync();
     this.dir = this.tmpDir.name;
-    this.repo = new GitRepo(this.dir, false);
-    execSync(`git clone https://github.com/dagster-io/dagster.git ${this.dir}`);
+    this.repo = new GitRepo(this.dir, { repoUrl: this.repoUrl });
     execSync(
       `git branch -r | grep -v '\\->' | while read remote; do git branch --track "\${remote#origin/}" "$remote"; done`,
       { cwd: this.dir }

--- a/test/lib/utils/configure_test.ts
+++ b/test/lib/utils/configure_test.ts
@@ -1,7 +1,7 @@
 import { AbstractScene } from "../scenes/abstract_scene";
 
 export function configureTest(suite: Mocha.Suite, scene: AbstractScene): void {
-  suite.timeout(60000);
+  suite.timeout(600000);
   suite.beforeEach(() => {
     scene.setup();
   });

--- a/test/slow/large_repo.test.ts
+++ b/test/slow/large_repo.test.ts
@@ -1,16 +1,27 @@
-import { BasicScene, LargeScene } from "../lib/scenes";
+import { PublicRepoScene } from "../lib/scenes";
 import { configureTest } from "../lib/utils";
 
-for (const scene of [new BasicScene(), new LargeScene()]) {
+for (const scene of [
+  new PublicRepoScene({
+    repoUrl: "https://github.com/SmartThingsCommunity/SmartThingsPublic.git",
+    name: "SmartThingsPublic",
+    timeout: 20000,
+  }),
+  new PublicRepoScene({
+    repoUrl: "https://github.com/dagster-io/dagster.git",
+    name: "Dagster",
+    timeout: 10000,
+  }),
+]) {
   describe(`(${scene}): Run simple timed commands`, function () {
     configureTest(this, scene);
 
     it("Can run stacks quickly", () => {
       scene.repo.execCliCommand(`log short`);
-    }).timeout(10000);
+    }).timeout(scene.timeout);
 
     it("Can run log quickly", () => {
       scene.repo.execCliCommand(`log`);
-    }).timeout(10000);
+    }).timeout(scene.timeout);
   });
 }


### PR DESCRIPTION
**Context:**
We heard reports of hanging on the SmartThingsRepo. I've updated slow tests to clone generic repos and test them with differing timeouts. SmartThingsPublic appears slower than Dagster, but now we have coverage that we can ratchet down overtime.

