### PR TITLE
ci(move_files): move stragglers into organized folders

### DIFF
--- a/.CHANGELOG
+++ b/.CHANGELOG
@@ -1,4 +1,7 @@
-# 0.10.1 2020-08-17
+# 0.11.0 2020-08-18
+- Support PR templates in "stack submit" command.
+- Update "stack submit" to support interactive title and description setting.
+- Update "stack submit" to support creating draft PRs.
 - Allow max branch length to be configured (from the default of 50).
 - Fix a crash in logging that happened in a edge case involving trailing trunk branches.
 - Hide remote branches in "log long" output.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphite-cli",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "None",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/fast/commands/branch/branch_checkout.test.ts
+++ b/test/fast/commands/branch/branch_checkout.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
-import { allScenes } from "../../lib/scenes";
-import { configureTest } from "../../lib/utils";
+import { allScenes } from "../../../lib/scenes";
+import { configureTest } from "../../../lib/utils";
 
 for (const scene of allScenes) {
   describe(`(${scene}): branch create`, function () {

--- a/test/fast/commands/log/short.test.ts
+++ b/test/fast/commands/log/short.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { execSync } from "child_process";
-import { TrailingProdScene } from "../../lib/scenes";
-import { configureTest } from "../../lib/utils";
+import { TrailingProdScene } from "../../../lib/scenes";
+import { configureTest } from "../../../lib/utils";
 
 for (const scene of [new TrailingProdScene()]) {
   describe(`(${scene}): log short`, function () {


### PR DESCRIPTION
**Context:**
Keep things organized - these tests must have accidentally missed a previous reorg.

