### PR TITLE
fix(trunk): disallow siblings on trunk branch

### DIFF
--- a/.CHANGELOG
+++ b/.CHANGELOG
@@ -1,4 +1,7 @@
-# 0.10.1 2020-08-17
+# 0.11.0 2020-08-18
+- Support PR templates in "stack submit" command.
+- Update "stack submit" to support interactive title and description setting.
+- Update "stack submit" to support creating draft PRs.
 - Allow max branch length to be configured (from the default of 50).
 - Fix a crash in logging that happened in a edge case involving trailing trunk branches.
 - Hide remote branches in "log long" output.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphite-cli",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "None",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/utils/trunk.ts
+++ b/src/lib/utils/trunk.ts
@@ -3,7 +3,7 @@ import fs from "fs-extra";
 import path from "path";
 import Branch from "../../wrapper-classes/branch";
 import { repoConfig } from "../config";
-import { ConfigError, ExitFailedError } from "../errors";
+import { ConfigError, ExitFailedError, SiblingBranchError } from "../errors";
 
 function findRemoteOriginBranch(): Branch | undefined {
   let config;
@@ -59,16 +59,22 @@ export function getTrunk(): Branch {
       );
     }
     memoizedTrunk = new Branch(configTrunkName);
-    return memoizedTrunk;
   }
 
   // No configured trunk, infer
-  const inferredTrunk = inferTrunk();
-  if (inferredTrunk) {
-    memoizedTrunk = inferredTrunk;
-    return memoizedTrunk;
+  if (!memoizedTrunk) {
+    const inferredTrunk = inferTrunk();
+    if (inferredTrunk) {
+      memoizedTrunk = inferredTrunk;
+      return memoizedTrunk;
+    }
+    throw new ConfigError(
+      `No configured trunk branch, and unable to infer. Consider setting the trunk name by running "gt repo init".`
+    );
   }
-  throw new ConfigError(
-    `No configured trunk branch, and unable to infer. Consider setting the trunk name by running "gt repo init".`
-  );
+  const trunkSiblings = memoizedTrunk.branchesWithSameCommit();
+  if (trunkSiblings.length > 0) {
+    throw new SiblingBranchError([memoizedTrunk].concat(trunkSiblings));
+  }
+  return memoizedTrunk;
 }

--- a/test/fast/commands/branch/branch_create.test.ts
+++ b/test/fast/commands/branch/branch_create.test.ts
@@ -9,6 +9,7 @@ for (const scene of allScenes) {
     it("Can run branch create", () => {
       scene.repo.execCliCommand(`branch create "a" -q`);
       expect(scene.repo.currentBranchName()).to.equal("a");
+      scene.repo.createChangeAndCommit("2", "2");
 
       scene.repo.execCliCommand("branch prev --no-interactive");
       expect(scene.repo.currentBranchName()).to.equal("main");

--- a/test/fast/commands/repo/trunk.test.ts
+++ b/test/fast/commands/repo/trunk.test.ts
@@ -13,5 +13,11 @@ for (const scene of allScenes) {
         scene.repo.execCliCommandAndGetOutput("repo trunk").includes("(main)")
       ).to.be.true;
     });
+
+    it("Throws an error if trunk has a sibling commit", () => {
+      expect(() => scene.repo.execCliCommand("ls")).to.not.throw(Error);
+      scene.repo.createAndCheckoutBranch("sibling");
+      expect(() => scene.repo.execCliCommand("ls")).to.throw(Error);
+    });
   });
 }


### PR DESCRIPTION
**Context:**
Graphite has strange behavior for sibling branches. We currently dont detect trunk siblings - lets fix that.

**Test Plan:**
Add a unit test to ensure that an actionable Sibling Error is thrown if trunk has a sibling.

