### PR TITLE
ci(slow_tests): break out in ci

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -12,7 +12,7 @@ on:
     branches: [main]
 
 jobs:
-  lint_build_test:
+  lint_and_fast_tests:
     runs-on: ubuntu-latest
     steps:
       # Basic setup
@@ -34,7 +34,29 @@ jobs:
       - name: Git Version
         run: git --version
       - name: Test
-        run: yarn test
+        run: yarn test-fast
+
+  slow_tests:
+    runs-on: ubuntu-latest
+    steps:
+      # Basic setup
+      - uses: actions/checkout@v2
+        with:
+          clean: "false"
+          fetch-depth: 0
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: 15.14.0
+      - name: Install
+        run: yarn install --immutable
+      - name: Build
+        run: yarn build
+      - name: Setup git
+        run: git config --global user.email "test@gmail.com" && git config --global user.name "test"
+      - name: Git Version
+        run: git --version
+      - name: Test
+        run: yarn test-slow
 
   # deploy_test:
   #   runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cli": "ts-node ./src/index.ts",
     "test": "yarn ts-mocha \"test/**/*.test.ts\"  --parallel --jobs 8",
     "test-fast": "yarn ts-mocha \"test/fast/**/*.test.ts\"  --parallel --jobs 8",
-    "test-slow": "yarn ts-mocha \"test/slow/**/*.test.ts\"  --parallel --jobs 8",
+    "test-slow": "yarn ts-mocha \"test/slow/**/*.test.ts\"",
     "test-one": "yarn ts-mocha --parallel --jobs 8",
     "test-grep": "yarn ts-mocha \"test/**/*.test.ts\" -g",
     "deploy": "ts-node ./scripts/deploy/deploy.ts",


### PR DESCRIPTION
**Context:**
Unsurprisingly, slow tests are proving flaky. Start by breaking them out on CI and stop parallelizing them.

