### PR TITLE
Replace globalArgs with execStateConfig

### DIFF
--- a/src/actions/commit_amend.ts
+++ b/src/actions/commit_amend.ts
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
+import { execStateConfig } from "../lib/config";
 import { ExitFailedError } from "../lib/errors";
-import { globalArgs } from "../lib/global-arguments";
 import { uncommittedChangesPrecondition } from "../lib/preconditions";
 import { gpExecSync, logWarn } from "../lib/utils";
 import { fixAction } from "./fix";
@@ -32,7 +32,7 @@ export async function commitAmendAction(opts: {
             ? [`-m ${opts.message}`]
             : [],
         ],
-        ...[globalArgs.noVerify ? ["--no-verify"] : []],
+        ...[execStateConfig.noVerify() ? ["--no-verify"] : []],
       ].join(" "),
       { stdio: "inherit" }
     );

--- a/src/actions/commit_create.ts
+++ b/src/actions/commit_create.ts
@@ -1,5 +1,5 @@
+import { execStateConfig } from "../lib/config";
 import { ExitFailedError } from "../lib/errors";
-import { globalArgs } from "../lib/global-arguments";
 import {
   ensureSomeStagedChangesPrecondition,
   uncommittedChangesPrecondition,
@@ -29,7 +29,7 @@ export async function commitCreateAction(opts: {
       command: [
         "git commit",
         `-m "${opts.message}"`,
-        ...[globalArgs.noVerify ? ["--no-verify"] : []],
+        ...[execStateConfig.noVerify() ? ["--no-verify"] : []],
       ].join(" "),
     },
     () => {

--- a/src/actions/create_branch.ts
+++ b/src/actions/create_branch.ts
@@ -1,6 +1,5 @@
-import { userConfig } from "../lib/config";
+import { execStateConfig, userConfig } from "../lib/config";
 import { ExitFailedError } from "../lib/errors";
-import { globalArgs } from "../lib/global-arguments";
 import {
   currentBranchPrecondition,
   ensureSomeStagedChangesPrecondition,
@@ -31,7 +30,7 @@ export async function createBranchAction(opts: {
     gpExecSync(
       {
         command: `git commit -m "${opts.commitMessage}" ${
-          globalArgs.noVerify ? "--no-verify" : ""
+          execStateConfig.noVerify() ? "--no-verify" : ""
         }`,
         options: {
           stdio: "inherit",

--- a/src/commands/branch-commands/next.ts
+++ b/src/commands/branch-commands/next.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { nextOrPrevAction } from "../../actions/next_or_prev";
-import { globalArgs } from "../../lib/global-arguments";
+import { execStateConfig } from "../../lib/config";
 import { profile } from "../../lib/telemetry";
 
 const args = {
@@ -25,7 +25,7 @@ export const handler = async (argv: argsT): Promise<void> => {
     await nextOrPrevAction({
       nextOrPrev: "next",
       numSteps: argv.steps,
-      interactive: globalArgs.interactive,
+      interactive: execStateConfig.interactive(),
     });
   });
 };

--- a/src/commands/branch-commands/prev.ts
+++ b/src/commands/branch-commands/prev.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { nextOrPrevAction } from "../../actions/next_or_prev";
-import { globalArgs } from "../../lib/global-arguments";
+import { execStateConfig } from "../../lib/config";
 import { profile } from "../../lib/telemetry";
 
 const args = {
@@ -25,7 +25,7 @@ export const handler = async (argv: argsT): Promise<void> => {
     await nextOrPrevAction({
       nextOrPrev: "prev",
       numSteps: argv.steps,
-      interactive: globalArgs.interactive,
+      interactive: execStateConfig.interactive(),
     });
   });
 };

--- a/src/commands/stack-commands/submit.ts
+++ b/src/commands/stack-commands/submit.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs";
 import { submitAction } from "../../actions/submit";
-import { globalArgs } from "../../lib/global-arguments";
+import { execStateConfig } from "../../lib/config";
 import { profile } from "../../lib/telemetry";
 
 export const command = "submit";
@@ -57,7 +57,7 @@ function getSubmitSettings(argv: argsT): {
   editPRFieldsInline: boolean;
   createNewPRsAsDraft: boolean | undefined;
 } {
-  if (!globalArgs.interactive) {
+  if (!execStateConfig.interactive()) {
     return {
       editPRFieldsInline: false,
       createNewPRsAsDraft: true,

--- a/src/lib/config/exec_state_config.ts
+++ b/src/lib/config/exec_state_config.ts
@@ -1,5 +1,8 @@
 type ExecStateConfigT = {
   outputDebugLogs?: boolean;
+  quiet?: boolean;
+  noVerify?: boolean;
+  interactive?: boolean;
 };
 
 /**
@@ -13,12 +16,40 @@ class ExecStateConfig {
     this._data = {};
   }
 
-  setOutputDebugLogs(outputDebugLogs: boolean): void {
+  setOutputDebugLogs(outputDebugLogs: boolean): this {
     this._data.outputDebugLogs = outputDebugLogs;
+    return this;
   }
 
   outputDebugLogs(): boolean {
     return this._data.outputDebugLogs ?? false;
+  }
+
+  setQuiet(quiet: boolean): this {
+    this._data.quiet = quiet;
+    return this;
+  }
+
+  quiet(): boolean {
+    return this._data.quiet ?? false;
+  }
+
+  setNoVerify(noVerify: boolean): this {
+    this._data.noVerify = noVerify;
+    return this;
+  }
+
+  noVerify(): boolean {
+    return this._data.noVerify ?? false;
+  }
+
+  setInteractive(interactive: boolean): this {
+    this._data.interactive = interactive;
+    return this;
+  }
+
+  interactive(): boolean {
+    return this._data.interactive ?? true;
   }
 }
 

--- a/src/lib/global-arguments/index.ts
+++ b/src/lib/global-arguments/index.ts
@@ -18,12 +18,11 @@ type argsT = yargs.Arguments<
 >;
 
 function processGlobalArgumentsMiddleware(argv: argsT): void {
-  globalArgs.quiet = argv.quiet;
-  globalArgs.noVerify = !argv.verify;
-  globalArgs.interactive = argv.interactive;
-  execStateConfig.setOutputDebugLogs(argv.debug);
+  execStateConfig
+    .setQuiet(argv.quiet)
+    .setNoVerify(!argv.verify)
+    .setInteractive(argv.interactive)
+    .setOutputDebugLogs(argv.debug);
 }
 
-const globalArgs = { quiet: false, noVerify: false, interactive: true };
-
-export { globalArgumentsOptions, processGlobalArgumentsMiddleware, globalArgs };
+export { globalArgumentsOptions, processGlobalArgumentsMiddleware };

--- a/src/lib/utils/splog.ts
+++ b/src/lib/utils/splog.ts
@@ -1,6 +1,5 @@
 import chalk from "chalk";
 import { execStateConfig, userConfig } from "../config";
-import { globalArgs } from "../global-arguments";
 
 export function logError(msg: string): void {
   console.log(chalk.redBright(`ERROR: ${msg}`));
@@ -11,13 +10,13 @@ export function logWarn(msg: string): void {
 }
 
 export function logInfo(msg: string): void {
-  if (!globalArgs.quiet) {
+  if (!execStateConfig.quiet()) {
     console.log(`${msg}`);
   }
 }
 
 export function logSuccess(msg: string): void {
-  if (!globalArgs.quiet) {
+  if (!execStateConfig.quiet()) {
     console.log(chalk.green(`${msg}`));
   }
 }
@@ -28,7 +27,7 @@ export function logDebug(msg: string): void {
   }
 }
 export function logTip(msg: string): void {
-  if (!globalArgs.quiet && userConfig.tipsEnabled()) {
+  if (!execStateConfig.quiet() && userConfig.tipsEnabled()) {
     console.log(
       chalk.gray(
         [
@@ -42,7 +41,7 @@ export function logTip(msg: string): void {
 }
 
 export function logNewline(): void {
-  if (!globalArgs.quiet) {
+  if (!execStateConfig.quiet()) {
     console.log("");
   }
 }


### PR DESCRIPTION
Refactoring `globalArgs` to move it into the `execStateConfig` object with setters/getters. Moving forward, `execStateConfig` will hold all of the in-memory state for the current invoked CLI command.