### PR TITLE
Add ability to infer repo name/owner from additional origin URL type

### DIFF
--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -2,13 +2,14 @@ import execStateConfig from "./exec_state_config";
 import messageConfig, {
   readMessageConfigForTestingOnly,
 } from "./message_config";
-import repoConfig from "./repo_config";
+import repoConfig, { getOwnerAndNameFromURLForTesting } from "./repo_config";
 import userConfig from "./user_config";
 
 export {
   messageConfig,
+  readMessageConfigForTestingOnly,
   userConfig,
   repoConfig,
-  readMessageConfigForTestingOnly,
+  getOwnerAndNameFromURLForTesting,
   execStateConfig,
 };

--- a/test/fast/commands/repo_config/repo_config.ts
+++ b/test/fast/commands/repo_config/repo_config.ts
@@ -1,0 +1,42 @@
+import { expect } from "chai";
+import { getOwnerAndNameFromURLForTesting } from "../../../../src/lib/config";
+import { BasicScene } from "../../../lib/scenes";
+import { configureTest } from "../../../lib/utils";
+
+for (const scene of [new BasicScene()]) {
+  describe(`(${scene}): infer repo owner/name`, function () {
+    configureTest(this, scene);
+
+    it("Can infer cloned repos", () => {
+      const { owner, name } = getOwnerAndNameFromURLForTesting(
+        "https://github.com/screenplaydev/graphite-cli.git"
+      );
+      expect(owner === "screenplaydev").to.be.true;
+      expect(name === "graphite-cli").to.be.true;
+    });
+
+    it("Can infer SSH cloned repos", () => {
+      const { owner, name } = getOwnerAndNameFromURLForTesting(
+        "git@github.com:screenplaydev/graphite-cli.git"
+      );
+      expect(owner === "screenplaydev").to.be.true;
+      expect(name === "graphite-cli").to.be.true;
+    });
+
+    // Not sure where these are coming from but we should be able to handle
+    // them.
+    it("Can infer cloned repos without .git", () => {
+      const clone = getOwnerAndNameFromURLForTesting(
+        "https://github.com/screenplaydev/graphite-cli"
+      );
+      expect(clone.owner === "screenplaydev").to.be.true;
+      expect(clone.name === "graphite-cli").to.be.true;
+
+      let sshClone = getOwnerAndNameFromURLForTesting(
+        "git@github.com:screenplaydev/graphite-cli"
+      );
+      expect(sshClone.owner === "screenplaydev").to.be.true;
+      expect(sshClone.name === "graphite-cli").to.be.true;
+    });
+  });
+}


### PR DESCRIPTION
Addressing the issue flagged [here](https://screenplaydev.slack.com/archives/C028QNXTNBF/p1629208065464800?thread_ts=1629207534.461600&cid=C028QNXTNBF).

Note sure where this comes from — the format of our repos for a regular clone, SSH key clone, or clone through the GitHub CLI — all include a `.git` suffix but this PR adds:
* support for this
* adds the offending URL to the error message so that it gets logged by us
  * in the long run, we should also introduce a way to send additional info along with our logs (so that we don't have to add this to our error message itself)