### PR TITLE
refactor(interactive_checkout): break out into another action

### DIFF
--- a/src/actions/interactive_checkout.ts
+++ b/src/actions/interactive_checkout.ts
@@ -1,0 +1,43 @@
+import prompts from "prompts";
+import { ExitCancelledError, ExitFailedError } from "../lib/errors";
+import { getTrunk, gpExecSync } from "../lib/utils";
+import { MetaStackBuilder } from "../wrapper-classes";
+import Branch from "../wrapper-classes/branch";
+
+export async function interactiveCheckout(): Promise<void> {
+  const stack = new MetaStackBuilder().fullStackFromBranch(getTrunk());
+  await promptBranches(stack.toPromptChoices());
+}
+
+type promptOptionT = { title: string; value: string };
+
+async function promptBranches(choices: promptOptionT[]): Promise<void> {
+  const currentBranch = Branch.getCurrentBranch();
+  let currentBranchIndex: undefined | number = undefined;
+
+  if (currentBranch) {
+    currentBranchIndex = choices
+      .map((c) => c.value)
+      .indexOf(currentBranch.name);
+  }
+
+  const chosenBranch = (
+    await prompts({
+      type: "select",
+      name: "branch",
+      message: `Checkout a branch`,
+      choices: choices,
+      ...(currentBranchIndex ? { initial: currentBranchIndex } : {}),
+    })
+  ).branch;
+
+  if (!chosenBranch) {
+    throw new ExitCancelledError("No branch selected");
+  }
+
+  if (chosenBranch && chosenBranch !== currentBranch?.name) {
+    gpExecSync({ command: `git checkout ${chosenBranch}` }, (err) => {
+      throw new ExitFailedError(`Failed to checkout ${chosenBranch}: ${err}`);
+    });
+  }
+}

--- a/src/commands/branch-commands/checkout.ts
+++ b/src/commands/branch-commands/checkout.ts
@@ -1,5 +1,5 @@
 import yargs from "yargs";
-import { stacksAction } from "../../actions/stacks";
+import { interactiveCheckout } from "../../actions/interactive_checkout";
 import { profile } from "../../lib/telemetry";
 import { gpExecSync } from "../../lib/utils";
 
@@ -23,7 +23,7 @@ export const handler = async (args: argsT): Promise<void> => {
     if (args.branch) {
       gpExecSync({ command: `git checkout ${args.branch}` });
     } else {
-      await stacksAction({ all: false, interactive: true });
+      await interactiveCheckout();
     }
   });
 };

--- a/src/commands/log-commands/short.ts
+++ b/src/commands/log-commands/short.ts
@@ -12,6 +12,6 @@ export const aliases = ["s"];
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, async () => {
-    await stacksAction({ all: false, interactive: false });
+    await stacksAction({ all: false });
   });
 };

--- a/src/wrapper-classes/stack.ts
+++ b/src/wrapper-classes/stack.ts
@@ -8,6 +8,19 @@ export default class Stack {
     this.source = source;
   }
 
+  public toPromptChoices(indent = 0): { title: string; value: string }[] {
+    let choices = [
+      {
+        title: `${"  ".repeat(indent)}↳ (${this.source.branch.name})`,
+        value: this.source.branch.name,
+      },
+    ];
+    this.source.children.forEach((c) => {
+      choices = choices.concat(new Stack(c).toPromptChoices(indent + 1));
+    });
+    return choices;
+  }
+
   public toString(): string {
     const indentMultilineString = (lines: string) =>
       lines


### PR DESCRIPTION
**Context:**

When we refactored the "Stacks" command, we never really split out the interactive checkout from log short. Lets do that now so that we can better iterate on log short