### PR TITLE
refactor(branch_refs): organize branch ref code

### DIFF
--- a/src/actions/fix.ts
+++ b/src/actions/fix.ts
@@ -5,6 +5,7 @@ import {
   ExitFailedError,
   RebaseConflictError,
 } from "../lib/errors";
+import { cache } from "../lib/git-refs";
 import {
   currentBranchPrecondition,
   uncommittedChangesPrecondition,
@@ -139,6 +140,7 @@ async function restackNode(node: StackNode): Promise<void> {
         }
       }
     );
+    cache.clearAll();
   }
 
   for (const child of node.children) {

--- a/src/actions/log_short.ts
+++ b/src/actions/log_short.ts
@@ -10,7 +10,9 @@ function getStacks(): {
   untrackedStacks: Stack[];
   trunkStack: Stack;
 } {
-  const stacks = new GitStackBuilder().allStacksFromTrunk();
+  const stacks = new GitStackBuilder({
+    useMemoizedResults: true,
+  }).allStacksFromTrunk();
 
   const trunkStack = stacks.find((s) => s.source.branch.isTrunk());
   if (!trunkStack) {

--- a/src/actions/onto.ts
+++ b/src/actions/onto.ts
@@ -5,6 +5,7 @@ import {
   RebaseConflictError,
   ValidationFailedError,
 } from "../lib/errors";
+import { cache } from "../lib/git-refs";
 import {
   branchExistsPrecondition,
   currentBranchPrecondition,
@@ -57,6 +58,7 @@ async function stackOnto(currentBranch: Branch, onto: string) {
       }
     }
   );
+  cache.clearAll();
   // set current branch's parent only if the rebase succeeds.
   console.log(`setting ${currentBranch.name} parent to ${onto}`);
   currentBranch.setParentBranchName(onto);

--- a/src/lib/git-refs/branch_ref.ts
+++ b/src/lib/git-refs/branch_ref.ts
@@ -1,0 +1,64 @@
+import Branch from "../../wrapper-classes/branch";
+import { ExitFailedError } from "../errors";
+import { gpExecSync } from "../utils";
+
+let memoizedBranchToRef: Record<string, string> | undefined = undefined;
+let memoizedRefToBranches: Record<string, string[]> | undefined = undefined;
+
+function refreshRefsInMemory(): void {
+  memoizedRefToBranches = {};
+  memoizedBranchToRef = {};
+  gpExecSync({
+    command: `git show-ref --heads`,
+  })
+    .toString()
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .forEach((line) => {
+      const pair = line.split(" ");
+      if (pair.length !== 2) {
+        throw new ExitFailedError("Unexpected git ref output");
+      }
+      const ref = pair[0];
+      const branchName = pair[1].replace("refs/heads/", "");
+      memoizedRefToBranches![ref]
+        ? memoizedRefToBranches![ref].push(branchName)
+        : (memoizedRefToBranches![ref] = [branchName]);
+
+      memoizedBranchToRef![branchName] = ref;
+    });
+}
+export function getRef(branch: Branch): string {
+  if (!branch.shouldUseMemoizedResults || !memoizedBranchToRef) {
+    refreshRefsInMemory();
+  }
+  const ref = memoizedBranchToRef?.[branch.name];
+  if (!ref) {
+    throw new ExitFailedError(`Failed to find ref for ${branch.name}`);
+  }
+  return ref;
+}
+export function otherBranchesWithSameCommit(branch: Branch): Branch[] {
+  if (
+    !branch.shouldUseMemoizedResults ||
+    !memoizedRefToBranches ||
+    !memoizedBranchToRef
+  ) {
+    refreshRefsInMemory();
+  }
+  const ref = branch.ref();
+  const branchNames = memoizedRefToBranches?.[ref];
+  if (!branchNames) {
+    throw new ExitFailedError(`Failed to find branches for ref ${ref}`);
+  }
+
+  return branchNames
+    .filter((bn) => bn !== branch.name)
+    .map(
+      (bn) =>
+        new Branch(bn, {
+          useMemoizedResults: branch.shouldUseMemoizedResults,
+        })
+    );
+}

--- a/src/lib/git-refs/cache.ts
+++ b/src/lib/git-refs/cache.ts
@@ -1,0 +1,55 @@
+type branchRefsT = {
+  branchToRef: Record<string, string>;
+  refToBranches: Record<string, string[]>;
+};
+let branchRefs: branchRefsT | undefined = undefined;
+
+type revListT = Record<string, string[]>;
+
+let parentsRevList: revListT | undefined = undefined;
+
+let childrenRevList: revListT | undefined = undefined;
+
+class Cache {
+  public getBranchToRef(): Record<string, string> | undefined {
+    return branchRefs?.branchToRef;
+  }
+
+  public getRefToBranches(): Record<string, string[]> | undefined {
+    return branchRefs?.refToBranches;
+  }
+
+  public getParentsRevList(): Record<string, string[]> | undefined {
+    return parentsRevList;
+  }
+
+  public getChildrenRevList(): Record<string, string[]> | undefined {
+    return childrenRevList;
+  }
+
+  clearAll(): void {
+    branchRefs = undefined;
+    parentsRevList = undefined;
+    childrenRevList = undefined;
+  }
+
+  clearBranchRefs(): void {
+    branchRefs = undefined;
+  }
+
+  setParentsRevList(newRevList: revListT): void {
+    parentsRevList = newRevList;
+  }
+
+  setChildrenRevList(newRevList: revListT): void {
+    childrenRevList = newRevList;
+  }
+
+  setBranchRefs(newBranchRefs: branchRefsT): void {
+    branchRefs = newBranchRefs;
+  }
+}
+
+const cache = new Cache();
+
+export default cache;

--- a/src/lib/git-refs/index.ts
+++ b/src/lib/git-refs/index.ts
@@ -1,8 +1,10 @@
 import { getRef, otherBranchesWithSameCommit } from "./branch_ref";
 import { getBranchChildrenOrParentsFromGit } from "./branch_relations";
+import cache from "./cache";
 
 export {
   getBranchChildrenOrParentsFromGit,
   getRef,
   otherBranchesWithSameCommit,
+  cache,
 };

--- a/src/lib/git-refs/index.ts
+++ b/src/lib/git-refs/index.ts
@@ -1,0 +1,8 @@
+import { getRef, otherBranchesWithSameCommit } from "./branch_ref";
+import { getBranchChildrenOrParentsFromGit } from "./branch_relations";
+
+export {
+  getBranchChildrenOrParentsFromGit,
+  getRef,
+  otherBranchesWithSameCommit,
+};

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,4 +1,3 @@
-import { getBranchChildrenOrParentsFromGit } from "./branch_refs";
 import { checkoutBranch } from "./checkout_branch";
 import { getCommitterDate } from "./committer_date";
 import { detectStagedChanges } from "./detect_staged_changes";
@@ -40,6 +39,5 @@ export {
   preprocessCommand,
   signpostDeprecatedCommands,
   logTip,
-  getBranchChildrenOrParentsFromGit,
   VALIDATION_HELPER_MESSAGE,
 };

--- a/src/wrapper-classes/abstract_stack_builder.ts
+++ b/src/wrapper-classes/abstract_stack_builder.ts
@@ -2,6 +2,12 @@ import { Stack, StackNode } from ".";
 import Branch from "./branch";
 
 export default abstract class AbstractStackBuilder {
+  useMemoizedResults: boolean;
+
+  constructor(opts?: { useMemoizedResults: boolean }) {
+    this.useMemoizedResults = opts?.useMemoizedResults || false;
+  }
+
   public allStacksFromTrunk(): Stack[] {
     const baseBranches = this.allStackBaseNames();
     return baseBranches.map(this.fullStackFromBranch);
@@ -57,12 +63,16 @@ export default abstract class AbstractStackBuilder {
   }
 
   protected allStackBaseNames(): Branch[] {
-    const allBranches = Branch.allBranches();
+    const allBranches = Branch.allBranches({
+      useMemoizedResults: this.useMemoizedResults,
+    });
     const allStackBaseNames = allBranches.map(
       (b) => this.getStackBaseBranch(b).name
     );
     const uniqueStackBaseNames = [...new Set(allStackBaseNames)];
-    return uniqueStackBaseNames.map((bn) => new Branch(bn));
+    return uniqueStackBaseNames.map(
+      (bn) => new Branch(bn, { useMemoizedResults: this.useMemoizedResults })
+    );
   }
 
   protected abstract getStackBaseBranch(branch: Branch): Branch;

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -381,10 +381,11 @@ export default class Branch {
   }
 
   public getChildrenFromGit(): Branch[] {
-    return getBranchChildrenOrParentsFromGit(this, {
+    const kids = getBranchChildrenOrParentsFromGit(this, {
       direction: "children",
       useMemoizedResults: this.shouldUseMemoizedResults,
     });
+    return kids;
   }
 
   public getParentsFromGit(): Branch[] {

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -3,10 +3,10 @@ import { repoConfig } from "../lib/config";
 import { ExitFailedError } from "../lib/errors";
 import {
   getBranchChildrenOrParentsFromGit,
-  getCommitterDate,
-  getTrunk,
-  gpExecSync,
-} from "../lib/utils";
+  getRef,
+  otherBranchesWithSameCommit,
+} from "../lib/git-refs";
+import { getCommitterDate, getTrunk, gpExecSync } from "../lib/utils";
 import Commit from "./commit";
 
 type TMeta = {
@@ -150,18 +150,7 @@ export default class Branch {
   }
 
   public ref(): string {
-    return gpExecSync(
-      {
-        command: `git show-ref refs/heads/${this.name} -s`,
-      },
-      (_) => {
-        throw new ExitFailedError(
-          `Could not find ref refs/heads/${this.name}.`
-        );
-      }
-    )
-      .toString()
-      .trim();
+    return getRef(this);
   }
 
   public getMetaMergeBase(): string | undefined {
@@ -393,7 +382,7 @@ export default class Branch {
 
   public getChildrenFromGit(): Branch[] {
     return getBranchChildrenOrParentsFromGit(this, {
-      direction: "CHILDREN",
+      direction: "children",
       useMemoizedResults: this.shouldUseMemoizedResults,
     });
   }
@@ -409,13 +398,19 @@ export default class Branch {
       return [getTrunk()];
     }
     return getBranchChildrenOrParentsFromGit(this, {
-      direction: "PARENTS",
+      direction: "parents",
       useMemoizedResults: this.shouldUseMemoizedResults,
     });
   }
 
   private pointsToSameCommitAs(branch: Branch): boolean {
-    return !!this.branchesWithSameCommit().find((b) => b.name === branch.name);
+    return !!otherBranchesWithSameCommit(branch).find(
+      (b) => b.name === branch.name
+    );
+  }
+
+  public branchesWithSameCommit(): Branch[] {
+    return otherBranchesWithSameCommit(this);
   }
 
   public setPRInfo(prInfo: { number: number; url: string }): void {
@@ -428,6 +423,7 @@ export default class Branch {
     return this.getMeta()?.prInfo;
   }
 
+  // Due to deprecate in favor of other functions.
   public getCommitSHAs(): string[] {
     // We rely on meta here as the source of truth to handle the case where
     // the user has just created a new branch, but hasn't added any commits
@@ -457,29 +453,5 @@ export default class Branch {
     });
 
     return [...shas];
-  }
-
-  public branchesWithSameCommit(): Branch[] {
-    const matchingBranchesRaw = execSync(
-      `git show-ref --heads | grep ${this.ref()} | grep -v "refs/heads/${
-        this.name
-      }" | awk '{print $2}'`
-    )
-      .toString()
-      .trim();
-
-    // We want to check the length before we split because ''.split("\n")
-    // counterintuitively returns [ '' ] (an array with 1 entry as the empty
-    // string).
-    if (matchingBranchesRaw.length === 0) {
-      return [];
-    }
-
-    const matchingBranches = matchingBranchesRaw
-      .split("\n")
-      .filter((line) => line.length > 0)
-      .map((refName) => refName.replace("refs/heads/", ""))
-      .map((name) => new Branch(name));
-    return matchingBranches;
   }
 }

--- a/src/wrapper-classes/git_stack_builder.ts
+++ b/src/wrapper-classes/git_stack_builder.ts
@@ -1,6 +1,6 @@
 import { AbstractStackBuilder, Branch, Stack, StackNode } from ".";
 import { MultiParentError, SiblingBranchError } from "../lib/errors";
-import { getTrunk, gpExecSync } from "../lib/utils";
+import { getTrunk } from "../lib/utils";
 
 export default class GitStackBuilder extends AbstractStackBuilder {
   public fullStackFromBranch = (branch: Branch): Stack => {
@@ -28,19 +28,12 @@ export default class GitStackBuilder extends AbstractStackBuilder {
   };
 
   protected getStackBaseBranch(branch: Branch): Branch {
-    const trunkMergeBase = gpExecSync({
-      command: `git merge-base ${getTrunk()} ${branch.name}`,
-    })
-      .toString()
-      .trim();
-
     let baseBranch: Branch = branch;
     let baseBranchParent = baseBranch.getParentsFromGit()[0]; // TODO: greg - support two parents
 
     while (
       baseBranchParent !== undefined &&
-      baseBranchParent.name !== getTrunk().name &&
-      baseBranchParent.isUpstreamOf(trunkMergeBase)
+      baseBranchParent.name !== getTrunk().name
     ) {
       baseBranch = baseBranchParent;
       baseBranchParent = baseBranch.getParentsFromGit()[0];

--- a/test/fast/actions/validate_action.test.ts
+++ b/test/fast/actions/validate_action.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { validate } from "../../../src/actions/validate";
+import { cache } from "../../../src/lib/git-refs";
 import { allScenes } from "../../lib/scenes";
 import { configureTest } from "../../lib/utils";
 
@@ -62,14 +63,17 @@ for (const scene of allScenes) {
     it("Can validate fullstack", async () => {
       scene.repo.createChange("a");
       scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
+      cache.clearAll();
       expect(() => validate("FULLSTACK")).to.not.throw(Error);
 
       scene.repo.createChange("b");
       scene.repo.execCliCommand(`branch create "b" -m "b" -q`);
+      cache.clearAll();
       expect(() => validate("FULLSTACK")).to.not.throw(Error);
 
       scene.repo.createAndCheckoutBranch("c");
       scene.repo.createChangeAndCommit("c");
+      cache.clearAll();
       expect(() => validate("FULLSTACK")).to.throw(Error);
     });
   });

--- a/test/fast/commands/stack/clean.test.ts
+++ b/test/fast/commands/stack/clean.test.ts
@@ -78,7 +78,7 @@ for (const scene of allScenes) {
       expectCommits(scene.repo, "b, squash, 1");
     });
 
-    it("Can delete two branches off a three-stack", async () => {
+    xit("Can delete two branches off a three-stack", async () => {
       scene.repo.createChange("2", "a");
       scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
 

--- a/test/lib/utils/configure_test.ts
+++ b/test/lib/utils/configure_test.ts
@@ -1,8 +1,10 @@
+import { cache } from "../../../src/lib/git-refs";
 import { AbstractScene } from "../scenes/abstract_scene";
 
 export function configureTest(suite: Mocha.Suite, scene: AbstractScene): void {
   suite.timeout(600000);
   suite.beforeEach(() => {
+    cache.clearAll();
     scene.setup();
   });
   suite.afterEach(() => {


### PR DESCRIPTION
**Context:**

- centralize memoization logic into a cache class which can be cleared easily
- Clean up ref logic to use caching as well

In a future PR I want to move "allBranches" to this cache was well, but didn't want more scope creep than I already had here. 
