### PR TITLE
refactor(stacks): clean up duplicate implementations

### DIFF
--- a/src/actions/fix.ts
+++ b/src/actions/fix.ts
@@ -160,7 +160,7 @@ async function regen(branch: Branch): Promise<void> {
 }
 
 function regenAllStacks(): void {
-  const allGitStacks = new GitStackBuilder().allStacksFromTrunk();
+  const allGitStacks = new GitStackBuilder().allStacks();
   logInfo(`Computing regenerating ${allGitStacks.length} stacks...`);
   allGitStacks.forEach((stack) => {
     logInfo(`\nRegenerating:\n${stack.toString()}`);

--- a/src/actions/log_short.ts
+++ b/src/actions/log_short.ts
@@ -12,7 +12,7 @@ function getStacks(): {
 } {
   const stacks = new GitStackBuilder({
     useMemoizedResults: true,
-  }).allStacksFromTrunk();
+  }).allStacks();
 
   const trunkStack = stacks.find((s) => s.source.branch.isTrunk());
   if (!trunkStack) {

--- a/src/wrapper-classes/abstract_stack_builder.ts
+++ b/src/wrapper-classes/abstract_stack_builder.ts
@@ -83,7 +83,7 @@ export default abstract class AbstractStackBuilder {
     }
 
     // If the parent is trunk (the only possibility because this is a off trunk)
-    const parent = this.getBranchParent(branch);
+    const parent = this.getBranchParent(stack.source.branch);
     if (parent && parent.name == getTrunk().name) {
       const trunkNode: StackNode = new StackNode({
         branch: getTrunk(),

--- a/src/wrapper-classes/abstract_stack_builder.ts
+++ b/src/wrapper-classes/abstract_stack_builder.ts
@@ -1,4 +1,5 @@
 import { Stack, StackNode } from ".";
+import { getTrunk } from "../lib/utils";
 import Branch from "./branch";
 
 export default abstract class AbstractStackBuilder {
@@ -8,12 +9,10 @@ export default abstract class AbstractStackBuilder {
     this.useMemoizedResults = opts?.useMemoizedResults || false;
   }
 
-  public allStacksFromTrunk(): Stack[] {
+  public allStacks(): Stack[] {
     const baseBranches = this.allStackBaseNames();
     return baseBranches.map(this.fullStackFromBranch);
   }
-
-  public abstract fullStackFromBranch(branch: Branch): Stack;
 
   public upstackInclusiveFromBranchWithParents(branch: Branch): Stack {
     const stack = this.fullStackFromBranch(branch);
@@ -62,12 +61,12 @@ export default abstract class AbstractStackBuilder {
     return new Stack(sourceNode);
   }
 
-  protected allStackBaseNames(): Branch[] {
+  private allStackBaseNames(): Branch[] {
     const allBranches = Branch.allBranches({
       useMemoizedResults: this.useMemoizedResults,
     });
     const allStackBaseNames = allBranches.map(
-      (b) => this.getStackBaseBranch(b).name
+      (b) => this.getStackBaseBranch(b, { excludingTrunk: false }).name
     );
     const uniqueStackBaseNames = [...new Set(allStackBaseNames)];
     return uniqueStackBaseNames.map(
@@ -75,7 +74,45 @@ export default abstract class AbstractStackBuilder {
     );
   }
 
-  protected abstract getStackBaseBranch(branch: Branch): Branch;
+  public fullStackFromBranch = (branch: Branch): Stack => {
+    const base = this.getStackBaseBranch(branch, { excludingTrunk: true });
+    const stack = this.upstackInclusiveFromBranchWithoutParents(base);
+
+    if (branch.name == getTrunk().name) {
+      return stack;
+    }
+
+    // If the parent is trunk (the only possibility because this is a off trunk)
+    const parent = this.getBranchParent(branch);
+    if (parent && parent.name == getTrunk().name) {
+      const trunkNode: StackNode = new StackNode({
+        branch: getTrunk(),
+        parent: undefined,
+        children: [stack.source],
+      });
+      stack.source.parent = trunkNode;
+      stack.source = trunkNode;
+    } else {
+      // To get in this state, the user must likely have changed their trunk branch...
+    }
+    return stack;
+  };
+
+  private getStackBaseBranch(
+    branch: Branch,
+    opts: { excludingTrunk: boolean }
+  ): Branch {
+    const parent = this.getBranchParent(branch);
+    if (!parent) {
+      return branch;
+    }
+    if (opts?.excludingTrunk && parent.isTrunk()) {
+      return branch;
+    }
+    return this.getStackBaseBranch(parent, opts);
+  }
+
+  protected abstract getBranchParent(branch: Branch): Branch | undefined;
   protected abstract getChildrenForBranch(branch: Branch): Branch[];
   protected abstract getParentForBranch(branch: Branch): Branch | undefined;
 }

--- a/src/wrapper-classes/git_stack_builder.ts
+++ b/src/wrapper-classes/git_stack_builder.ts
@@ -1,45 +1,9 @@
-import { AbstractStackBuilder, Branch, Stack, StackNode } from ".";
+import { AbstractStackBuilder, Branch } from ".";
 import { MultiParentError, SiblingBranchError } from "../lib/errors";
-import { getTrunk } from "../lib/utils";
 
 export default class GitStackBuilder extends AbstractStackBuilder {
-  public fullStackFromBranch = (branch: Branch): Stack => {
-    const base = this.getStackBaseBranch(branch);
-    const stack = this.upstackInclusiveFromBranchWithoutParents(base);
-
-    const parents = base.getParentsFromGit();
-    const parentsIncludeTrunk = parents
-      .map((parent) => parent.name)
-      .includes(getTrunk().name);
-
-    // If the parents don't include trunk, just return.
-    if (!parentsIncludeTrunk) {
-      return stack;
-    }
-
-    const trunkNode: StackNode = new StackNode({
-      branch: getTrunk(),
-      parent: undefined,
-      children: [stack.source],
-    });
-    stack.source.parent = trunkNode;
-    stack.source = trunkNode;
-    return stack;
-  };
-
-  protected getStackBaseBranch(branch: Branch): Branch {
-    let baseBranch: Branch = branch;
-    let baseBranchParent = baseBranch.getParentsFromGit()[0]; // TODO: greg - support two parents
-
-    while (
-      baseBranchParent !== undefined &&
-      baseBranchParent.name !== getTrunk().name
-    ) {
-      baseBranch = baseBranchParent;
-      baseBranchParent = baseBranch.getParentsFromGit()[0];
-    }
-
-    return baseBranch;
+  protected getBranchParent(branch: Branch): Branch | undefined {
+    return branch.getParentsFromGit()[0];
   }
 
   protected getChildrenForBranch(branch: Branch): Branch[] {

--- a/src/wrapper-classes/meta_stack_builder.ts
+++ b/src/wrapper-classes/meta_stack_builder.ts
@@ -1,42 +1,10 @@
-import { AbstractStackBuilder, Stack, StackNode } from ".";
-import { getTrunk } from "../lib/utils";
+import { AbstractStackBuilder } from ".";
 import Branch from "./branch";
 
 export default class MetaStackBuilder extends AbstractStackBuilder {
-  protected getStackBaseBranch(branch: Branch): Branch {
-    const parent = branch.getParentFromMeta();
-    if (!parent) {
-      return branch;
-    }
-    if (parent.name == getTrunk().name) {
-      return branch;
-    }
-    return this.getStackBaseBranch(parent);
+  protected getBranchParent(branch: Branch): Branch | undefined {
+    return branch.getParentFromMeta();
   }
-
-  public fullStackFromBranch = (branch: Branch): Stack => {
-    const base = this.getStackBaseBranch(branch);
-    const stack = this.upstackInclusiveFromBranchWithoutParents(base);
-
-    if (branch.name == getTrunk().name) {
-      return stack;
-    }
-
-    // If the parent is trunk (the only possibility because this is a off trunk)
-    const parent = base.getParentFromMeta();
-    if (parent && parent.name == getTrunk().name) {
-      const trunkNode: StackNode = new StackNode({
-        branch: getTrunk(),
-        parent: undefined,
-        children: [stack.source],
-      });
-      stack.source.parent = trunkNode;
-      stack.source = trunkNode;
-    } else {
-      // To get in this state, the user must likely have changed their trunk branch...
-    }
-    return stack;
-  };
 
   protected getChildrenForBranch(branch: Branch): Branch[] {
     return branch.getChildrenFromMeta();

--- a/test/fast/wrapper-classes/stack_builder.test.ts
+++ b/test/fast/wrapper-classes/stack_builder.test.ts
@@ -65,7 +65,6 @@ for (const scene of allScenes) {
 
       // Expect git and meta stacks to equal
       expect(gitStacks[0].equals(metaStacks[0])).to.be.true;
-      expect(gitStacks[1].equals(metaStacks[1])).to.be.true;
     });
 
     it("Can get full stack from a branch", () => {

--- a/test/fast/wrapper-classes/stack_builder.test.ts
+++ b/test/fast/wrapper-classes/stack_builder.test.ts
@@ -28,14 +28,14 @@ for (const scene of allScenes) {
       scene.repo.createAndCheckoutBranch("d");
       scene.repo.createChangeAndCommit("d");
 
-      const gitStacks = new GitStackBuilder().allStacksFromTrunk();
-      const metaStacks = new MetaStackBuilder().allStacksFromTrunk();
+      const gitStacks = new GitStackBuilder().allStacks();
+      const metaStacks = new MetaStackBuilder().allStacks();
 
       expect(
-        gitStacks[0].equals(Stack.fromMap({ main: { a: { b: { c: {} } } } }))
+        gitStacks[0].equals(
+          Stack.fromMap({ main: { d: {}, a: { b: { c: {} } } } })
+        )
       ).to.be.true;
-      expect(gitStacks[1].equals(Stack.fromMap({ main: { d: {} } }))).to.be
-        .true;
 
       // Expect default meta to be 4 stacks of 1 off main.
       expect(metaStacks[0].equals(Stack.fromMap({ main: { a: {} } })));
@@ -56,13 +56,12 @@ for (const scene of allScenes) {
       scene.repo.createChange("d");
       scene.repo.execCliCommand(`branch create "d" -m "d" -q`);
 
-      const metaStacks = new MetaStackBuilder().allStacksFromTrunk();
-      const gitStacks = new GitStackBuilder().allStacksFromTrunk();
+      const metaStacks = new MetaStackBuilder().allStacks();
+      const gitStacks = new GitStackBuilder().allStacks();
 
-      expect(metaStacks[0].equals(Stack.fromMap({ main: { a: { b: {} } } }))).to
-        .be.true;
-      expect(metaStacks[1].equals(Stack.fromMap({ main: { d: {} } }))).to.be
-        .true;
+      expect(
+        metaStacks[0].equals(Stack.fromMap({ main: { d: {}, a: { b: {} } } }))
+      ).to.be.true;
 
       // Expect git and meta stacks to equal
       expect(gitStacks[0].equals(metaStacks[0])).to.be.true;


### PR DESCRIPTION
**Context:**
This started with me noticing a small bug in `gt ls`. I realized our implementation of `allStacksFromTrunk` was confusing and could be simplified into `allStacks`. I then moved the meta and git stack builder methods into the abstract class to further unify traversal logic - a lot of our edge bugs come from divergences in these stack traversals.
