### PR TITLE
ci(debug): print stack traces when debug output enabled

### DIFF
--- a/src/lib/telemetry/profile.ts
+++ b/src/lib/telemetry/profile.ts
@@ -5,7 +5,7 @@ import yargs from "yargs";
 import { postTelemetryInBackground } from ".";
 import { version } from "../../../package.json";
 import { init } from "../../actions/init";
-import { repoConfig } from "../config";
+import { execStateConfig, repoConfig } from "../config";
 import {
   ConfigError,
   ExitCancelledError,
@@ -96,6 +96,9 @@ export async function profile(
     );
   } catch (err) {
     const end = Date.now();
+    if (execStateConfig.outputDebugLogs()) {
+      logError(err);
+    }
     postTelemetryInBackground({
       commandName: parsedArgs.command,
       durationMiliSeconds: end - start,

--- a/test/lib/scenes/abstract_scene.ts
+++ b/test/lib/scenes/abstract_scene.ts
@@ -1,6 +1,7 @@
 import { execSync } from "child_process";
 import fs from "fs-extra";
 import tmp from "tmp";
+import { execStateConfig } from "../../../src/lib/config";
 import { GitRepo } from "../../../src/lib/utils";
 
 export abstract class AbstractScene {
@@ -28,6 +29,7 @@ export abstract class AbstractScene {
     process.chdir(this.dir);
     if (process.env.DEBUG) {
       console.log(`Dir: ${this.dir}`);
+      execStateConfig.setOutputDebugLogs(true);
     }
   }
 


### PR DESCRIPTION
**Context:**
When debugging tests, we hide the stack traces. Let's change this suchg that when we use the DEBUG=true or run a command with the debug flag, we print error stack traces.

