### PR TITLE
fix(debug_output): correctly log error trace

### DIFF
--- a/src/lib/telemetry/profile.ts
+++ b/src/lib/telemetry/profile.ts
@@ -98,7 +98,8 @@ export async function profile(
   } catch (err) {
     const end = Date.now();
     if (execStateConfig.outputDebugLogs()) {
-      logError(err);
+      logInfo(err);
+      logInfo(err.stack);
     }
     postTelemetryInBackground({
       commandName: parsedArgs.command,


### PR DESCRIPTION
**Context:**
I previously assumed that logging the error would also print the trace. It didn't, so Im correcting this attempt.
