### PR TITLE
perf(refs): dont fetch all refs for logging

### DIFF
--- a/src/lib/telemetry/context.ts
+++ b/src/lib/telemetry/context.ts
@@ -1,18 +1,4 @@
 import { execSync } from "child_process";
-export function getNumBranches(): number | undefined {
-  try {
-    return parseInt(execSync("git branch | wc -l").toString().trim());
-  } catch {
-    return undefined;
-  }
-}
-export function getNumCommitObjects(): number | undefined {
-  try {
-    return parseInt(execSync("git rev-list --all | wc -l").toString().trim());
-  } catch {
-    return undefined;
-  }
-}
 
 export function getUserEmail(): string | undefined {
   try {

--- a/src/lib/telemetry/index.ts
+++ b/src/lib/telemetry/index.ts
@@ -1,4 +1,4 @@
-import { getNumBranches, getNumCommitObjects, getUserEmail } from "./context";
+import { getUserEmail } from "./context";
 import { postTelemetryInBackground } from "./post_traces";
 import { profile } from "./profile";
 import { registerSigintHandler } from "./sigint_handler";
@@ -9,8 +9,6 @@ const SHOULD_REPORT_TELEMETRY = process.env.NODE_ENV != "development";
 
 export {
   tracer,
-  getNumBranches,
-  getNumCommitObjects,
   profile,
   getUserEmail,
   SHOULD_REPORT_TELEMETRY,

--- a/src/lib/telemetry/profile.ts
+++ b/src/lib/telemetry/profile.ts
@@ -23,7 +23,7 @@ import {
   parseArgs,
   VALIDATION_HELPER_MESSAGE,
 } from "../utils";
-import { getNumBranches, getNumCommitObjects, getUserEmail } from "./context";
+import { getUserEmail } from "./context";
 import tracer from "./tracer";
 
 export async function profile(
@@ -41,9 +41,6 @@ export async function profile(
     await init();
   }
 
-  const numCommits = getNumCommitObjects();
-  const numBranches = getNumBranches();
-
   try {
     await tracer.span(
       {
@@ -54,8 +51,6 @@ export async function profile(
           version: version,
           args: parsedArgs.args,
           alias: parsedArgs.alias,
-          ...(numCommits ? { commits: numCommits.toString() } : {}),
-          ...(numBranches ? { branches: numBranches.toString() } : {}),
         },
       },
       async () => {


### PR DESCRIPTION
**Context:**
We originally ran these commands so that we could log the number of commits and branches a user has. For large repos, counting refs can take 5+ seconds. Some users with large repos are hitting this, so lets remove this logging in the name of perf.
