### PR TITLE
[Submit] Ensure 'title' field is defined

### DIFF
--- a/src/actions/submit.ts
+++ b/src/actions/submit.ts
@@ -250,7 +250,7 @@ async function getPRCreationInfo(args: {
       message: "Title",
       initial: title,
     });
-    title = response.title;
+    title = response.title ?? title;
   }
 
   let body = await getPRTemplate();


### PR DESCRIPTION
**Context:**

My suspicion is that this was the culprit for one of the submit 500s earlier today — I noticed that `title`, a required field was missing.

**Changes In This Pull Request:**

This PR prevents if from being undefined if the prompts library returns undefined.

**Test Plan:**

Could repro a 500 by giving prompts EOF on the `title` field; after the change, the server behaves correctly. I'll also reach out to the 500 user directly to verify the fix.

