### PR TITLE
feat(telemetry): log when cli is killed

### DIFF
--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -42,6 +42,13 @@ class ConfigError extends ExitError {
   }
 }
 
+class KilledError extends ExitError {
+  constructor() {
+    super(`User killed Graphite early`);
+    this.name = "Killed";
+  }
+}
+
 class SiblingBranchError extends ExitError {
   constructor(branches: Branch[]) {
     super(
@@ -80,4 +87,5 @@ export {
   ExitCancelledError,
   SiblingBranchError,
   MultiParentError,
+  KilledError,
 };

--- a/src/lib/telemetry/index.ts
+++ b/src/lib/telemetry/index.ts
@@ -1,6 +1,7 @@
 import { getNumBranches, getNumCommitObjects, getUserEmail } from "./context";
 import { postTelemetryInBackground } from "./post_traces";
 import { profile } from "./profile";
+import { registerSigintHandler } from "./sigint_handler";
 import tracer from "./tracer";
 import { fetchUpgradePromptInBackground } from "./upgrade_prompt";
 
@@ -15,4 +16,5 @@ export {
   SHOULD_REPORT_TELEMETRY,
   fetchUpgradePromptInBackground,
   postTelemetryInBackground,
+  registerSigintHandler,
 };

--- a/src/lib/telemetry/profile.ts
+++ b/src/lib/telemetry/profile.ts
@@ -2,7 +2,7 @@
 // We the creators want to understand how people are using the tool
 // All metrics logged are listed plain to see, and are non blocking in case the server is unavailable.
 import yargs from "yargs";
-import { postTelemetryInBackground } from ".";
+import { postTelemetryInBackground, registerSigintHandler } from ".";
 import { version } from "../../../package.json";
 import { init } from "../../actions/init";
 import { execStateConfig, repoConfig } from "../config";
@@ -32,6 +32,8 @@ export async function profile(
 ): Promise<void> {
   // Self heal repo config on all commands besides init:
   const parsedArgs = parseArgs(args);
+  const start = Date.now();
+  registerSigintHandler({ commandName: parsedArgs.command, startTime: start });
   if (parsedArgs.command !== "repo init" && !repoConfig.getTrunk()) {
     logInfo(
       `No trunk branch specified in "${repoConfig.path()}", please choose now.`
@@ -39,7 +41,6 @@ export async function profile(
     await init();
   }
 
-  const start = Date.now();
   const numCommits = getNumCommitObjects();
   const numBranches = getNumBranches();
 

--- a/src/lib/telemetry/sigint_handler.ts
+++ b/src/lib/telemetry/sigint_handler.ts
@@ -1,0 +1,25 @@
+import { postTelemetryInBackground, tracer } from ".";
+import { KilledError } from "../errors";
+
+export function registerSigintHandler(opts: {
+  commandName: string;
+  startTime: number;
+}): void {
+  process.on("SIGINT", () => {
+    console.log(`Gracefully terminating...`);
+    const err = new KilledError();
+    // End all current traces abruptly.
+    tracer.allSpans.forEach((s) => s.end(err));
+    postTelemetryInBackground({
+      commandName: opts.commandName,
+      durationMiliSeconds: Date.now() - opts.startTime,
+      err: {
+        errName: err.name,
+        errMessage: err.message,
+        errStack: err.stack || "",
+      },
+    });
+    // eslint-disable-next-line no-restricted-syntax
+    process.exit(0);
+  });
+}


### PR DESCRIPTION
**Context:**
We have a current issue where we dont have any telemetry on when users are killing the CLI early. This means we're blind to hangs and other problems.

Let's handle the sigints and log to the server under a new error type.

example:
![image](https://user-images.githubusercontent.com/4308672/130702971-a928d59d-9049-4d35-af40-2070abdc024a.png)
