### PR TITLE
[gpExecSync] Add 'printStdout' option

### DIFF
--- a/src/actions/submit.ts
+++ b/src/actions/submit.ts
@@ -100,6 +100,9 @@ function pushBranchesToRemote(branches: Branch[]): Branch[] {
         // of the push command to stderr 2) we want to analyze it but Node's
         // execSync makes analyzing stderr extremely challenging
         command: `git push origin -f ${branch.name} 2>&1`,
+        options: {
+          printStdout: true,
+        },
       },
       (_) => {
         throw new ExitFailedError(
@@ -109,9 +112,6 @@ function pushBranchesToRemote(branches: Branch[]): Branch[] {
     )
       .toString()
       .trim();
-
-    console.log(output);
-    logNewline();
 
     if (!output.includes("Everything up-to-date")) {
       branchesPushedToRemote.push(branch);


### PR DESCRIPTION
**Context:**

In the submit command, we want to introspect on the output of gpExecSync -- but we also still want it to output to the terminal so tha the user can see the progress of the push.

The result of this is that we capture the output and console.log it ourselves.

This looks a bit odd (I can see someone thinking this is a stray console.log in the future) so let's just bake this functionality into gpExecSync itself.

**Changes In This Pull Request:**

Adds new functionality; migrates submit callsite mentioned above.

**Test Plan:**

yarn build + test submit to make sure output on pushes is still there
