### PR TITLE
[SP-1452] add all on branch create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ xcuserdata/
 dist/
 .eslintcache
 .graphite_repo_config
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ xcuserdata/
 dist/
 .eslintcache
 .graphite_repo_config
-.idea/*

--- a/src/actions/create_branch.ts
+++ b/src/actions/create_branch.ts
@@ -20,13 +20,13 @@ export async function createBranchAction(opts: {
           command: "git add --all",
         },
         () => {
-          throw new ExitFailedError("Failed to add changes. Aborting...");
+          throw new ExitFailedError("Could not add all staged changes. Aborting...");
         }
     );
   }
 
   if (opts.commitMessage) {
-    ensureSomeStagedChangesPrecondition();
+    ensureSomeStagedChangesPrecondition("Use -a option to stage all unstaged changes.");
   }
 
   const branchName = newBranchName(opts.branchName, opts.commitMessage);

--- a/src/actions/create_branch.ts
+++ b/src/actions/create_branch.ts
@@ -10,8 +10,20 @@ import Branch from "../wrapper-classes/branch";
 export async function createBranchAction(opts: {
   branchName?: string;
   commitMessage?: string;
+  addAll?: boolean
 }): Promise<void> {
   const parentBranch = currentBranchPrecondition();
+
+  if (opts.addAll) {
+    gpExecSync(
+        {
+          command: "git add --all",
+        },
+        () => {
+          throw new ExitFailedError("Failed to add changes. Aborting...");
+        }
+    );
+  }
 
   if (opts.commitMessage) {
     ensureSomeStagedChangesPrecondition();

--- a/src/actions/create_branch.ts
+++ b/src/actions/create_branch.ts
@@ -26,7 +26,7 @@ export async function createBranchAction(opts: {
   }
 
   if (opts.commitMessage) {
-    ensureSomeStagedChangesPrecondition("Use -a option to stage all unstaged changes.");
+    ensureSomeStagedChangesPrecondition(true);
   }
 
   const branchName = newBranchName(opts.branchName, opts.commitMessage);

--- a/src/commands/branch-commands/create.ts
+++ b/src/commands/branch-commands/create.ts
@@ -16,6 +16,13 @@ const args = {
     type: "string",
     alias: "m",
   },
+  "add-all": {
+    describe: `Stage all un-staged changes on the new branch with this message.`,
+    demandOption: false,
+    default: false,
+    type: "boolean",
+    alias: "a",
+  },
 } as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
@@ -29,6 +36,7 @@ export const handler = async (argv: argsT): Promise<void> => {
     await createBranchAction({
       branchName: argv.name,
       commitMessage: argv["commit-message"],
+      addAll: argv["add-all"],
     });
   });
 };

--- a/src/lib/preconditions/index.ts
+++ b/src/lib/preconditions/index.ts
@@ -1,7 +1,15 @@
 import Branch from "../../wrapper-classes/branch";
 import { repoConfig, userConfig } from "../config";
 import { PreconditionsFailedError } from "../errors";
-import { detectStagedChanges, gpExecSync, uncommittedChanges } from "../utils";
+import {detectStagedChanges, gpExecSync, logTip, uncommittedChanges, unStagedChanges} from "../utils";
+
+function addAllAvailableTip(): void {
+  if (unStagedChanges()) {
+    logTip(
+        "There are unstaged changes. Use -a option to stage all unstaged changes."
+    );
+  }
+}
 
 function currentBranchPrecondition(): Branch {
   const branch = Branch.getCurrentBranch();
@@ -37,10 +45,13 @@ function uncommittedChangesPrecondition(): void {
   }
 }
 
-function ensureSomeStagedChangesPrecondition(message?: string): void {
+function ensureSomeStagedChangesPrecondition(addAllLogTipEnabled?: boolean): void {
   if (!detectStagedChanges()) {
     gpExecSync({ command: `git status`, options: { stdio: "ignore" } });
-    throw new PreconditionsFailedError(`Cannot run without staged changes. ${message}`);
+    if (addAllLogTipEnabled) {
+      addAllAvailableTip();
+    }
+    throw new PreconditionsFailedError(`Cannot run without staged changes.`);
   }
 }
 

--- a/src/lib/preconditions/index.ts
+++ b/src/lib/preconditions/index.ts
@@ -37,10 +37,10 @@ function uncommittedChangesPrecondition(): void {
   }
 }
 
-function ensureSomeStagedChangesPrecondition(): void {
+function ensureSomeStagedChangesPrecondition(message?: string): void {
   if (!detectStagedChanges()) {
     gpExecSync({ command: `git status`, options: { stdio: "ignore" } });
-    throw new PreconditionsFailedError(`Cannot run without staged changes.`);
+    throw new PreconditionsFailedError(`Cannot run without staged changes. ${message}`);
   }
 }
 

--- a/src/lib/utils/exec_sync.ts
+++ b/src/lib/utils/exec_sync.ts
@@ -16,7 +16,7 @@ export function gpExecSync(
   onError?: (e: Error) => void
 ): Buffer {
   try {
-    // Only measure if we're with an exisiting span.
+    // Only measure if we're with an existing span.
     if (tracer.currentSpanId) {
       return tracer.spanSync(
         {

--- a/src/lib/utils/git_repo.ts
+++ b/src/lib/utils/git_repo.ts
@@ -1,6 +1,7 @@
 import { execSync } from "child_process";
 import fs from "fs-extra";
 import { rebaseInProgress } from "./";
+import { unStagedChanges } from "./";
 
 const TEXT_FILE_NAME = "test.txt";
 export default class GitRepo {
@@ -39,6 +40,17 @@ export default class GitRepo {
     )
       .toString()
       .trim();
+  }
+
+  createUnstagedChange(textValue: string, prefix?: string): void {
+    const filePath = `${this.dir}/${
+        prefix ? prefix + "_" : ""
+    }${TEXT_FILE_NAME}`;
+    fs.writeFileSync(filePath, textValue);
+  }
+
+  unstagedChanges(): boolean {
+    return unStagedChanges();
   }
 
   createChange(textValue: string, prefix?: string): void {

--- a/src/lib/utils/git_repo.ts
+++ b/src/lib/utils/git_repo.ts
@@ -42,23 +42,18 @@ export default class GitRepo {
       .trim();
   }
 
-  createUnstagedChange(textValue: string, prefix?: string): void {
-    const filePath = `${this.dir}/${
-        prefix ? prefix + "_" : ""
-    }${TEXT_FILE_NAME}`;
-    fs.writeFileSync(filePath, textValue);
-  }
-
   unstagedChanges(): boolean {
     return unStagedChanges();
   }
 
-  createChange(textValue: string, prefix?: string): void {
+  createChange(textValue: string, prefix?: string, unstaged?: boolean): void {
     const filePath = `${this.dir}/${
       prefix ? prefix + "_" : ""
     }${TEXT_FILE_NAME}`;
     fs.writeFileSync(filePath, textValue);
-    execSync(`git -C "${this.dir}" add ${filePath}`);
+    if (!unstaged) {
+      execSync(`git -C "${this.dir}" add ${filePath}`);
+    }
   }
 
   createChangeAndCommit(textValue: string, prefix?: string): void {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -19,6 +19,7 @@ import {
 } from "./splog";
 import { getTrunk } from "./trunk";
 import { uncommittedChanges } from "./uncommitted_changes";
+import { unStagedChanges } from "./unstaged_changes";
 import { VALIDATION_HELPER_MESSAGE } from "./validation_helper_message";
 
 export {
@@ -32,6 +33,7 @@ export {
   rebaseInProgress,
   detectStagedChanges,
   uncommittedChanges,
+  unStagedChanges,
   getTrunk,
   GitRepo,
   parseArgs,

--- a/src/lib/utils/unstaged_changes.ts
+++ b/src/lib/utils/unstaged_changes.ts
@@ -1,0 +1,18 @@
+import { gpExecSync } from ".";
+import { ExitFailedError } from "../errors";
+export function unStagedChanges(): boolean {
+    return (
+        gpExecSync(
+            {
+                command: `git status -u --porcelain=v1 2>/dev/null | wc -l`,
+            },
+            () => {
+                throw new ExitFailedError(
+                    `Failed to check current dir for unstaged changes.`
+                );
+            }
+        )
+            .toString()
+            .trim() !== "0"
+    );
+}

--- a/test/fast/commands/branch/branch_create.test.ts
+++ b/test/fast/commands/branch/branch_create.test.ts
@@ -16,7 +16,7 @@ for (const scene of allScenes) {
     });
 
     it("Can rollback changes on a failed commit hook", () => {
-      // Agressive AF commit hook from your angry coworker
+      // Aggressive AF commit hook from your angry coworker
       scene.repo.createPrecommitHook("exit 1");
       scene.repo.createChange("2");
       expect(() => {
@@ -30,6 +30,13 @@ for (const scene of allScenes) {
       scene.repo.execCliCommand(`branch create -m "feat(test): info" -q`);
       expect(scene.repo.currentBranchName().includes("feat_test_info")).to.be
         .true;
+    });
+
+    it("Can create a branch with add all option", () => {
+      scene.repo.createUnstagedChange("23");
+      expect(scene.repo.unstagedChanges()).to.be.true
+      scene.repo.execCliCommand(`branch create test-branch -m "add all" -a -q`);
+      expect(scene.repo.unstagedChanges()).to.be.false
     });
 
     it("Cant create a branch off an ignored branch", () => {

--- a/test/fast/commands/branch/branch_create.test.ts
+++ b/test/fast/commands/branch/branch_create.test.ts
@@ -33,7 +33,7 @@ for (const scene of allScenes) {
     });
 
     it("Can create a branch with add all option", () => {
-      scene.repo.createUnstagedChange("23");
+      scene.repo.createChange("23", "", true);
       expect(scene.repo.unstagedChanges()).to.be.true
       scene.repo.execCliCommand(`branch create test-branch -m "add all" -a -q`);
       expect(scene.repo.unstagedChanges()).to.be.false


### PR DESCRIPTION
**Context:** -a flag (all) should `git add --all` before making a possible commit on the new branch. 



**Changes In This Pull Request:**

1. Changes to support -a flag on `branch create`
2. Tests to ensure that changes work as expected
3. Helper functions and utils for tests

**Test Plan:**

Automated: `yarn test-fast`

Manual: 

1. Make changes. Do not add or commit those changes. 
2. Use `git status -u` these changes should appear as untracked files.
3. Use `gt branch create -m "<branch name>" -a`. 
4. Check that all the changes that were untracked before were committed into the newly created branch above.
