### PR TITLE
refactor(clean): rename to repo sync

### DIFF
--- a/src/actions/sync.ts
+++ b/src/actions/sync.ts
@@ -1,7 +1,6 @@
 import chalk from "chalk";
 import { execSync } from "child_process";
 import prompts from "prompts";
-import { ontoAction } from "../actions/onto";
 import { ExitFailedError, PreconditionsFailedError } from "../lib/errors";
 import { currentBranchPrecondition } from "../lib/preconditions";
 import {
@@ -12,13 +11,14 @@ import {
   uncommittedChanges,
 } from "../lib/utils";
 import Branch from "../wrapper-classes/branch";
+import { ontoAction } from "./onto";
 
-export async function cleanAction(opts: {
+export async function syncAction(opts: {
   pull: boolean;
   force: boolean;
 }): Promise<void> {
   if (uncommittedChanges()) {
-    throw new PreconditionsFailedError("Cannot clean with uncommitted changes");
+    throw new PreconditionsFailedError("Cannot sync with uncommitted changes");
   }
 
   const oldBranch = currentBranchPrecondition();

--- a/src/commands/repo-commands/repo_sync.ts
+++ b/src/commands/repo-commands/repo_sync.ts
@@ -1,5 +1,5 @@
 import yargs from "yargs";
-import { cleanAction } from "../../actions/clean";
+import { syncAction } from "../../actions/sync";
 import { profile } from "../../lib/telemetry";
 
 const args = {
@@ -20,14 +20,14 @@ const args = {
 } as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
-export const command = "clean";
-export const aliases = ["c"];
+export const command = "sync";
+export const aliases = ["s"];
 export const description =
   "Delete any branches that have been merged or squashed into the trunk branch, and fix their upstack branches recursively.";
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, async () => {
-    await cleanAction({
+    await syncAction({
       pull: argv.pull,
       force: argv.force,
     });

--- a/test/fast/commands/repo/sync.test.ts
+++ b/test/fast/commands/repo/sync.test.ts
@@ -38,7 +38,7 @@ function expectBranches(repo: GitRepo, sortedBranches: string) {
 
 for (const scene of allScenes) {
   // eslint-disable-next-line max-lines-per-function
-  describe(`(${scene}): stack clean`, function () {
+  describe(`(${scene}): repo sync`, function () {
     configureTest(this, scene);
 
     it("Can delete a single merged branch", async () => {
@@ -48,13 +48,13 @@ for (const scene of allScenes) {
       expectBranches(scene.repo, "a, main");
 
       fakeGitSquashAndMerge(scene.repo, "a", "squash");
-      scene.repo.execCliCommand(`stack clean -qf`);
+      scene.repo.execCliCommand(`repo sync -qf`);
 
       expectBranches(scene.repo, "main");
     });
 
-    it("Can noop clean if there are no stacks", () => {
-      expect(() => scene.repo.execCliCommand(`stack clean -qf`)).to.not.throw(
+    it("Can noop sync if there are no stacks", () => {
+      expect(() => scene.repo.execCliCommand(`repo sync -qf`)).to.not.throw(
         Error
       );
     });
@@ -69,7 +69,7 @@ for (const scene of allScenes) {
       expectBranches(scene.repo, "a, b, main");
 
       fakeGitSquashAndMerge(scene.repo, "a", "squash");
-      scene.repo.execCliCommand(`stack clean -qf`);
+      scene.repo.execCliCommand(`repo sync -qf`);
 
       expectBranches(scene.repo, "b, main");
       expectCommits(scene.repo, "squash, 1");
@@ -92,7 +92,7 @@ for (const scene of allScenes) {
 
       fakeGitSquashAndMerge(scene.repo, "a", "squash_a");
       fakeGitSquashAndMerge(scene.repo, "b", "squash_b");
-      scene.repo.execCliCommand(`stack clean -qf`);
+      scene.repo.execCliCommand(`repo sync -qf`);
 
       expectBranches(scene.repo, "c, main");
       expectCommits(scene.repo, "squash_b, squash_a, 1");
@@ -111,9 +111,9 @@ for (const scene of allScenes) {
       expectBranches(scene.repo, "a, b, c, main");
 
       fakeGitSquashAndMerge(scene.repo, "a", "squash_a");
-      scene.repo.execCliCommand(`stack clean -qf`);
+      scene.repo.execCliCommand(`repo sync -qf`);
       fakeGitSquashAndMerge(scene.repo, "b", "squash_b");
-      scene.repo.execCliCommand(`stack clean -qf`);
+      scene.repo.execCliCommand(`repo sync -qf`);
 
       expectBranches(scene.repo, "c, main");
       expectCommits(scene.repo, "squash_b, squash_a, 1");
@@ -143,7 +143,7 @@ for (const scene of allScenes) {
       fakeGitSquashAndMerge(scene.repo, "b", "squash_b");
       fakeGitSquashAndMerge(scene.repo, "d", "squash_d");
 
-      scene.repo.execCliCommand(`stack clean -qf`);
+      scene.repo.execCliCommand(`repo sync -qf`);
 
       expectBranches(scene.repo, "c, e, main");
       scene.repo.checkoutBranch("main");


### PR DESCRIPTION
**Context:**
Refactor clean into `repo sync` because the command operates on all branches within the repo, and we plan to also have the command help clean metadata from the .git/refs/branch-metadata folder.
