### PR TITLE
util(metadataRef): start pattern of metadata_ref wrapper class

### DIFF
--- a/src/wrapper-classes/index.ts
+++ b/src/wrapper-classes/index.ts
@@ -2,6 +2,7 @@ import AbstractStackBuilder from "./abstract_stack_builder";
 import Branch from "./branch";
 import Commit from "./commit";
 import GitStackBuilder from "./git_stack_builder";
+import MetadataRef from "./metadata_ref";
 import MetaStackBuilder from "./meta_stack_builder";
 import Stack from "./stack";
 import StackNode from "./stack_node";
@@ -14,4 +15,5 @@ export {
   Branch,
   Commit,
   StackNode,
+  MetadataRef,
 };

--- a/src/wrapper-classes/metadata_ref.ts
+++ b/src/wrapper-classes/metadata_ref.ts
@@ -1,0 +1,31 @@
+import fs from "fs-extra";
+import path from "path";
+import { ExitFailedError } from "../lib/errors";
+import { getRepoRootPath } from "../lib/utils";
+
+export default class MetadataRef {
+  _branchName: string;
+  _path: string;
+
+  constructor(branchName: string) {
+    this._branchName = branchName;
+    this._path = path.join(
+      getRepoRootPath(),
+      `refs/branch-metadata/`,
+      branchName
+    );
+  }
+
+  public rename(newBranchName: string): void {
+    if (!fs.existsSync(this._path)) {
+      throw new ExitFailedError(
+        `No Graphite metadata ref found at ${this._path}`
+      );
+    }
+    fs.moveSync(
+      path.join(this._path),
+      path.join(path.dirname(this._path), newBranchName)
+    );
+    this._branchName = newBranchName;
+  }
+}


### PR DESCRIPTION
**Context:**
We now have multiple commands that interact with metadata refs - sync, rename, etc. Lets move into a wrapper class to handle better.
