### PR TITLE
Fix branches without parents method

### DIFF
--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -324,7 +324,7 @@ export default class Branch {
         if (opts?.excludeTrunk && branch.name === getTrunk().name) {
           return false;
         }
-        return !!branch.getParentFromGit;
+        return branch.getParentFromGit() === undefined;
       },
       opts: opts,
     });


### PR DESCRIPTION
**Context:**

`getAllBranchesWithoutParents` is broken; this PR fixes it.

**Changes In This Pull Request:**

As titled.

**Test Plan:**

Originally noticed that branches were appearing multiples times in the output of `gt log`. This PR eliminates the problem for me locally.
