### PR TITLE
[Log] Show commit info per branch

### DIFF
--- a/src/actions/print_stack.ts
+++ b/src/actions/print_stack.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import { getCommitterDate } from "../lib/utils";
 import { getTrunk } from "../lib/utils/trunk";
+import { Commit } from "../wrapper-classes";
 import Branch from "../wrapper-classes/branch";
 import { TBranchPRInfo } from "../wrapper-classes/metadata_ref";
 
@@ -90,6 +91,18 @@ function getBranchInfo(branch: Branch, config: TPrintStackConfig): string[] {
       })
     )}`
   );
+
+  if (!branch.isTrunk()) {
+    const commits = branch.getCommitSHAs();
+    if (commits.length !== 0) {
+      commits.forEach((commitSHA) => {
+        const commit = new Commit(commitSHA);
+        branchInfoLines.push(
+          chalk.gray(`* ${commit.sha.slice(0, 6)} - ${commit.message()}`)
+        );
+      });
+    }
+  }
 
   branchInfoLines = dimMergedOrClosedBranches({
     lines: branchInfoLines,

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -444,6 +444,10 @@ export default class Branch {
     // - so both branch tips point to the same commit. Graphite knows that
     // this is a parent-child relationship, but git does not.
     const parent = this.getParentFromMeta();
+    if (parent === undefined) {
+      return [];
+    }
+
     const shas: Set<string> = new Set();
 
     const commits = gpExecSync(


### PR DESCRIPTION
**Context:**

Sometimes it's helpful to see the commit info as well.

**Test Plan:**

| Before | After |
| -- | -- |
| <img width="535" alt="Screen Shot 2021-08-30 at 4 44 39 PM" src="https://user-images.githubusercontent.com/9063972/131410443-b6e452b6-afcd-42ec-87df-941bd9dca853.png"> | <img width="548" alt="Screen Shot 2021-08-30 at 4 44 10 PM" src="https://user-images.githubusercontent.com/9063972/131410450-2f863326-2d5b-44f4-9da6-f8a44eda5aac.png"> |