### PR TITLE
[Log] Rate limit API requests

### DIFF
--- a/src/lib/config/repo_config.ts
+++ b/src/lib/config/repo_config.ts
@@ -22,6 +22,7 @@ type RepoConfigT = {
   maxStacksShownBehindTrunk?: number;
   maxDaysShownBehindTrunk?: number;
   maxBranchLength?: number;
+  lastFetchedPRInfoMs?: number;
 };
 
 class RepoConfig {
@@ -154,6 +155,15 @@ class RepoConfig {
 
   public setMaxBranchLength(numCommits: number) {
     this._data.maxBranchLength = numCommits;
+    this.save();
+  }
+
+  public getLastFetchedPRInfoMs(): number | undefined {
+    return this._data.lastFetchedPRInfoMs;
+  }
+
+  public setLastFetchedPRInfoMs(time: number) {
+    this._data.lastFetchedPRInfoMs = time;
     this.save();
   }
 }


### PR DESCRIPTION
**Context:**

Now that we'll be making background fetches for PR information in log, we want to make sure to rate limit these so that users don't run into GitHub API limits.

**Changes In This Pull Request:**

This PR sets the limit to a max of 1 PR info request per minute. In reality, this will be lower because these requests are only kicked off when a user runs a Graphite command. As a result, the real consumption rate here is the time between Graphite command invocations or increments of one minute — whichever is greater.

**Test Plan:**

Printed if in the rate limit case; verified it was triggering locally.

