### PR TITLE
revert(siblings): undo tie breaking logic for git traversal

### DIFF
--- a/src/lib/utils/trunk.ts
+++ b/src/lib/utils/trunk.ts
@@ -3,7 +3,7 @@ import fs from "fs-extra";
 import path from "path";
 import Branch from "../../wrapper-classes/branch";
 import { repoConfig } from "../config";
-import { ConfigError, ExitFailedError } from "../errors";
+import { ConfigError, ExitFailedError, SiblingBranchError } from "../errors";
 
 function findRemoteOriginBranch(): Branch | undefined {
   let config;
@@ -71,6 +71,10 @@ export function getTrunk(): Branch {
     throw new ConfigError(
       `No configured trunk branch, and unable to infer. Consider setting the trunk name by running "gt repo init".`
     );
+  }
+  const trunkSiblings = memoizedTrunk.branchesWithSameCommit();
+  if (trunkSiblings.length > 0) {
+    throw new SiblingBranchError([memoizedTrunk].concat(trunkSiblings));
   }
   return memoizedTrunk;
 }

--- a/src/wrapper-classes/git_stack_builder.ts
+++ b/src/wrapper-classes/git_stack_builder.ts
@@ -1,15 +1,29 @@
 import { AbstractStackBuilder, Branch } from ".";
+import { MultiParentError, SiblingBranchError } from "../lib/errors";
 
 export default class GitStackBuilder extends AbstractStackBuilder {
   protected getBranchParent(branch: Branch): Branch | undefined {
-    return branch.getParentFromGit();
+    return branch.getParentsFromGit()[0];
   }
 
   protected getChildrenForBranch(branch: Branch): Branch[] {
+    this.checkSiblingBranches(branch);
     return branch.getChildrenFromGit();
   }
 
   protected getParentForBranch(branch: Branch): Branch | undefined {
-    return branch.getParentFromGit();
+    this.checkSiblingBranches(branch);
+    const parents = branch.getParentsFromGit();
+    if (parents.length > 1) {
+      throw new MultiParentError(branch, parents);
+    }
+    return parents[0];
+  }
+
+  private checkSiblingBranches(branch: Branch): void {
+    const siblingBranches = branch.branchesWithSameCommit();
+    if (siblingBranches.length > 0) {
+      throw new SiblingBranchError([branch].concat(siblingBranches));
+    }
   }
 }

--- a/test/fast/commands/log/short.test.ts
+++ b/test/fast/commands/log/short.test.ts
@@ -28,14 +28,10 @@ for (const scene of [new TrailingProdScene()]) {
       expect(() => scene.repo.execCliCommand(`log short`)).to.not.throw(Error);
     });
 
-    it("Can print correctly if trunk has two branches pointing to one commit", () => {
+    it("Errors if trunk has two branches pointing to one commit", () => {
       scene.repo.execCliCommand(`branch create a`);
       scene.repo.checkoutBranch("main");
-      scene.repo.createChange("b", "b");
-      scene.repo.execCliCommand(`branch create b -m "b"`);
-      expect(
-        scene.repo.execCliCommandAndGetOutput("log short").split("\n").length
-      ).to.eq(3, "number of lines from ls output");
+      expect(() => scene.repo.execCliCommand("log short")).to.throw(Error);
     });
   });
 }

--- a/test/fast/commands/log/short.test.ts
+++ b/test/fast/commands/log/short.test.ts
@@ -27,5 +27,15 @@ for (const scene of [new TrailingProdScene()]) {
       // b's now has no git-parents, but it's meta points to "a" which still exists but is not off main.
       expect(() => scene.repo.execCliCommand(`log short`)).to.not.throw(Error);
     });
+
+    it("Can print correctly if trunk has two branches pointing to one commit", () => {
+      scene.repo.execCliCommand(`branch create a`);
+      scene.repo.checkoutBranch("main");
+      scene.repo.createChange("b", "b");
+      scene.repo.execCliCommand(`branch create b -m "b"`);
+      expect(
+        scene.repo.execCliCommandAndGetOutput("log short").split("\n").length
+      ).to.eq(3, "number of lines from ls output");
+    });
   });
 }

--- a/test/fast/commands/repo/sync.test.ts
+++ b/test/fast/commands/repo/sync.test.ts
@@ -132,7 +132,7 @@ for (const scene of allScenes) {
         .be.false;
     });
 
-    it("Can detect dead branches off multiple stacks", async () => {
+    xit("Can detect dead branches off multiple stacks", async () => {
       scene.repo.createChange("a", "a");
       scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
 

--- a/test/fast/commands/repo/trunk.test.ts
+++ b/test/fast/commands/repo/trunk.test.ts
@@ -14,9 +14,10 @@ for (const scene of allScenes) {
       ).to.be.true;
     });
 
-    it("Does not throw an error if trunk has a sibling commit WITH meta", () => {
-      scene.repo.execCliCommand("branch create 'sibling' -q");
+    it("Throws an error if trunk has a sibling commit", () => {
       expect(() => scene.repo.execCliCommand("ls")).to.not.throw(Error);
+      scene.repo.createAndCheckoutBranch("sibling");
+      expect(() => scene.repo.execCliCommand("ls")).to.throw(Error);
     });
   });
 }

--- a/test/fast/wrapper-classes/branch.test.ts
+++ b/test/fast/wrapper-classes/branch.test.ts
@@ -12,7 +12,7 @@ for (const scene of allScenes) {
       scene.repo.execCliCommand(`branch create a -m "a" -q`);
 
       const branch = new Branch("a");
-      expect(branch.getParentFromGit()?.name).to.equal("main");
+      expect(branch.getParentsFromGit()[0].name).to.equal("main");
     });
 
     it("Can list parent based on meta for a branch", () => {

--- a/test/fast/wrapper-classes/stack_builder.test.ts
+++ b/test/fast/wrapper-classes/stack_builder.test.ts
@@ -133,31 +133,18 @@ for (const scene of allScenes) {
       expect(gitStack.equals(Stack.fromMap({ a: {} }))).to.be.true;
     });
 
-    it("Does not throw an error if two git branches point to the same commit WITH meta", () => {
+    it("Throws an error if two git branches point to the same commit", () => {
       scene.repo.createChange("a");
       scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
+
+      expect(() =>
+        new GitStackBuilder().fullStackFromBranch(new Branch("a"))
+      ).to.not.throw(Error);
 
       scene.repo.execCliCommand(`branch create "b" -q`);
 
       expect(() =>
         new GitStackBuilder().fullStackFromBranch(new Branch("a"))
-      ).to.not.throw(SiblingBranchError);
-      expect(
-        new GitStackBuilder()
-          .fullStackFromBranch(new Branch("a"))
-          .equals(Stack.fromMap({ main: { a: { b: {} } } }))
-      ).to.be.true;
-    });
-
-    it("Throws an error if two git branches point to the same commit WITHOUT meta", () => {
-      scene.repo.createChange("a");
-      scene.repo.createAndCheckoutBranch("a");
-
-      scene.repo.createChange("b");
-      scene.repo.createAndCheckoutBranch("b");
-
-      expect(() =>
-        new GitStackBuilder().fullStackFromBranch(new Branch("b"))
       ).to.throw(SiblingBranchError);
     });
 


### PR DESCRIPTION
**Context:**
Using meta to break ties in sibling branches is causing more problems than we'd like. Revert for now while we test alternative solutions.
