### PR TITLE
[Submit] Share boilerplate between submit commands

### DIFF
--- a/src/commands/branch-commands/submit.ts
+++ b/src/commands/branch-commands/submit.ts
@@ -1,29 +1,10 @@
-import yargs from "yargs";
 import { submitAction } from "../../actions/submit";
 import { profile } from "../../lib/telemetry";
+import type { argsT } from "../shared-commands/submit";
 
-export const command = "submit";
+export { aliases, args, builder, command } from "../shared-commands/submit";
 export const description =
   "Idempotently force push the current branch to GitHub, creating or updating a pull request.";
-
-const args = {
-  draft: {
-    describe:
-      "Creates new PRs in draft mode. If --no-interactive is true, this is automatically set to true.",
-    type: "boolean",
-    alias: "d",
-  },
-  edit: {
-    describe:
-      "Edit PR fields inline. If --no-interactive is true, this is automatically set to false.",
-    type: "boolean",
-    default: true,
-    alias: "e",
-  },
-} as const;
-export const builder = args;
-export const aliases = ["s"];
-export type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
 export const handler = async (argv: argsT): Promise<void> => {
   await profile(argv, async () => {

--- a/src/commands/downstack-commands/submit.ts
+++ b/src/commands/downstack-commands/submit.ts
@@ -1,14 +1,11 @@
 import { submitAction } from "../../actions/submit";
 import { profile } from "../../lib/telemetry";
-import {
-  aliases,
-  argsT,
-  builder,
-  command,
-  description,
-} from "../stack-commands/submit";
+import type { argsT } from "../shared-commands/submit";
 
-export { command, description, builder, aliases };
+export { aliases, builder, command } from "../shared-commands/submit";
+export const description =
+  "Idempotently force push all downstack branches (including the current one) to GitHub, creating or updating distinct pull requests for each.";
+
 export const handler = async (argv: argsT): Promise<void> => {
   await profile(argv, async () => {
     await submitAction({

--- a/src/commands/shared-commands/submit.ts
+++ b/src/commands/shared-commands/submit.ts
@@ -1,0 +1,39 @@
+import yargs from "yargs";
+
+export const command = "submit";
+
+/**
+ * Primary interaction patterns:
+ *
+ * # (default) allows user to edit PR fields inline and then submits stack as a draft
+ * gt stack submit
+ *
+ * # skips editing PR fields inline, submits stack as a draft
+ * gt stack submit --no-edit
+ *
+ * # allows user to edit PR fields inline, then publishes
+ * gt stack submit --no-draft
+ *
+ * # same as gt stack submit --no-edit
+ * gt stack submit --no-interactive
+ *
+ */
+export const args = {
+  draft: {
+    describe:
+      "Creates new PRs in draft mode. If --no-interactive is true, this is automatically set to true.",
+    type: "boolean",
+    alias: "d",
+  },
+  edit: {
+    describe:
+      "Edit PR fields inline. If --no-interactive is true, this is automatically set to false.",
+    type: "boolean",
+    default: true,
+    alias: "e",
+  },
+} as const;
+
+export const builder = args;
+export const aliases = ["s"];
+export type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;

--- a/src/commands/stack-commands/submit.ts
+++ b/src/commands/stack-commands/submit.ts
@@ -1,45 +1,10 @@
-import yargs from "yargs";
 import { submitAction } from "../../actions/submit";
 import { profile } from "../../lib/telemetry";
+import type { argsT } from "../shared-commands/submit";
 
-export const command = "submit";
+export { aliases, args, builder, command } from "../shared-commands/submit";
 export const description =
   "Idempotently force push all branches in the current stack to GitHub, creating or updating distinct pull requests for each.";
-
-/**
- * Primary interaction patterns:
- *
- * # (default) allows user to edit PR fields inline and then submits stack as a draft
- * gt stack submit
- *
- * # skips editing PR fields inline, submits stack as a draft
- * gt stack submit --no-edit
- *
- * # allows user to edit PR fields inline, then publishes
- * gt stack submit --no-draft
- *
- * # same as gt stack submit --no-edit
- * gt stack submit --no-interactive
- *
- */
-const args = {
-  draft: {
-    describe:
-      "Creates new PRs in draft mode. If --no-interactive is true, this is automatically set to true.",
-    type: "boolean",
-    alias: "d",
-  },
-  edit: {
-    describe:
-      "Edit PR fields inline. If --no-interactive is true, this is automatically set to false.",
-    type: "boolean",
-    default: true,
-    alias: "e",
-  },
-} as const;
-export const builder = args;
-export const aliases = ["s"];
-export type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
 export const handler = async (argv: argsT): Promise<void> => {
   await profile(argv, async () => {

--- a/src/commands/upstack-commands/submit.ts
+++ b/src/commands/upstack-commands/submit.ts
@@ -1,29 +1,10 @@
-import yargs from "yargs";
 import { submitAction } from "../../actions/submit";
 import { profile } from "../../lib/telemetry";
+import { argsT } from "../shared-commands/submit";
 
-export const command = "submit";
+export { aliases, args, builder, command } from "../shared-commands/submit";
 export const description =
   "Idempotently force push the upstack branches to GitHub, creating or updating pull requests as necessary.";
-
-const args = {
-  draft: {
-    describe:
-      "Creates new PRs in draft mode. If --no-interactive is true, this is automatically set to true.",
-    type: "boolean",
-    alias: "d",
-  },
-  edit: {
-    describe:
-      "Edit PR fields inline. If --no-interactive is true, this is automatically set to false.",
-    type: "boolean",
-    default: true,
-    alias: "e",
-  },
-} as const;
-export const builder = args;
-export const aliases = ["s"];
-export type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
 export const handler = async (argv: argsT): Promise<void> => {
   await profile(argv, async () => {


### PR DESCRIPTION
**Context:**

As titled.

**Changes In This Pull Request:**

Shares everything but description (command-specific) between the upstack, downstack, stack, and branch submit commands.

**Test Plan:**

yarn build

