### PR TITLE
fix(cancel): improve logging when killing during prompt

### DIFF
--- a/src/actions/interactive_checkout.ts
+++ b/src/actions/interactive_checkout.ts
@@ -1,9 +1,5 @@
 import prompts from "prompts";
-import {
-  ExitCancelledError,
-  ExitFailedError,
-  KilledError,
-} from "../lib/errors";
+import { ExitCancelledError, ExitFailedError } from "../lib/errors";
 import { getTrunk, gpExecSync } from "../lib/utils";
 import { MetaStackBuilder } from "../wrapper-classes";
 import Branch from "../wrapper-classes/branch";
@@ -36,7 +32,7 @@ async function promptBranches(choices: promptOptionT[]): Promise<void> {
       },
       {
         onCancel: () => {
-          throw new KilledError();
+          return;
         },
       }
     )

--- a/src/lib/telemetry/profile.ts
+++ b/src/lib/telemetry/profile.ts
@@ -10,6 +10,7 @@ import {
   ConfigError,
   ExitCancelledError,
   ExitFailedError,
+  KilledError,
   MultiParentError,
   PreconditionsFailedError,
   RebaseConflictError,
@@ -83,6 +84,8 @@ export async function profile(
             case MultiParentError:
               logError(err.message);
               throw err;
+            case KilledError:
+              return; // don't log output if user manually kills.
             default:
               logError(err.message);
               throw err;


### PR DESCRIPTION
**Context:**
I noticed that cntr-c from `gt bco` gave a nasty error message, but behaved correctly. This PR tones down logging when cancelling out of a command.
