### PR TITLE
fix(trunk): ignore sibling branches correctly

### DIFF
--- a/src/lib/config/repo_config.ts
+++ b/src/lib/config/repo_config.ts
@@ -39,6 +39,10 @@ class RepoConfig {
     );
   }
 
+  isNotIgnoredBranch(branchName: string) {
+    return !this.getIgnoreBranches().includes(branchName);
+  }
+
   public getRepoOwner(): string {
     const configOwner = this._data.owner;
     if (configOwner) {

--- a/src/lib/git-refs/branch_ref.ts
+++ b/src/lib/git-refs/branch_ref.ts
@@ -1,4 +1,5 @@
 import Branch from "../../wrapper-classes/branch";
+import { repoConfig } from "../config";
 import cache from "../config/cache";
 import { ExitFailedError } from "../errors";
 import { gpExecSync } from "../utils";
@@ -21,11 +22,12 @@ function refreshRefsCache(): void {
       }
       const ref = pair[0];
       const branchName = pair[1].replace("refs/heads/", "");
-      memoizedRefToBranches[ref]
-        ? memoizedRefToBranches[ref].push(branchName)
-        : (memoizedRefToBranches[ref] = [branchName]);
-
-      memoizedBranchToRef[branchName] = ref;
+      if (repoConfig.isNotIgnoredBranch(branchName)) {
+        memoizedRefToBranches[ref]
+          ? memoizedRefToBranches[ref].push(branchName)
+          : (memoizedRefToBranches[ref] = [branchName]);
+        memoizedBranchToRef[branchName] = ref;
+      }
     });
   cache.setBranchRefs({
     branchToRef: memoizedBranchToRef,

--- a/test/fast/commands/repo/trunk.test.ts
+++ b/test/fast/commands/repo/trunk.test.ts
@@ -19,5 +19,18 @@ for (const scene of allScenes) {
       scene.repo.createAndCheckoutBranch("sibling");
       expect(() => scene.repo.execCliCommand("ls")).to.throw(Error);
     });
+
+    it("Can get trunk if there is an ignored branch pointing to the same commit", () => {
+      scene.repo.createAndCheckoutBranch("ignore-me");
+      scene.repo.checkoutBranch("main");
+      expect(() => scene.repo.execCliCommand("ls")).to.throw(Error);
+
+      scene.repo.execCliCommand("repo ignored-branches --add ignore-me");
+      expect(() => scene.repo.execCliCommand("ls")).to.not.throw(Error);
+
+      expect(
+        scene.repo.execCliCommandAndGetOutput("repo trunk").includes("(main)")
+      ).to.be.true;
+    });
   });
 }


### PR DESCRIPTION
**Context:**
A user reported a bug where their ignored trailing branch caught up to main and started causing sibling errors.

Update the code to more correcly ignore "ignored-branches", including when checking for sibling branches.
