### PR TITLE
feat(state_capture): command to summarize repo state

### DIFF
--- a/src/commands/feedback-commands/debug_context.ts
+++ b/src/commands/feedback-commands/debug_context.ts
@@ -1,0 +1,31 @@
+import chalk from "chalk";
+import yargs from "yargs";
+import { captureState, recreateState } from "../../lib/debug-context";
+import { profile } from "../../lib/telemetry";
+import { logInfo } from "../../lib/utils";
+
+const args = {
+  recreate: {
+    type: "string",
+    optional: true,
+    describe:
+      "Accepts a json block created by `gt feedback state`. Recreates a debug repo in a temp folder with a commit tree matching the state JSON.",
+  },
+} as const;
+type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
+
+export const command = "debug-context";
+export const description =
+  "Print a debug summary of your repo. Useful for creating bug report details.";
+export const builder = args;
+
+export const handler = async (argv: argsT): Promise<void> => {
+  return profile(argv, async () => {
+    if (argv.recreate) {
+      const dir = recreateState(argv.recreate);
+      logInfo(`${chalk.green(dir)}`);
+    } else {
+      logInfo(captureState());
+    }
+  });
+};

--- a/src/lib/debug-context/index.ts
+++ b/src/lib/debug-context/index.ts
@@ -1,0 +1,164 @@
+import fs from "fs-extra";
+import path from "path";
+import tmp from "tmp";
+import MetadataRef from "../../wrapper-classes/metadata_ref";
+import { repoConfig, userConfig } from "../config";
+import { getBranchToRefMapping } from "../git-refs/branch_ref";
+import { getRevListGitTree } from "../git-refs/branch_relations";
+import { currentBranchPrecondition } from "../preconditions";
+import { gpExecSync, logInfo } from "../utils";
+
+type stateT = {
+  refTree: Record<string, string[]>;
+  branchToRefMapping: Record<string, string>;
+  userConfig: string;
+  repoConfig: string;
+  metadata: Record<string, string>;
+};
+export function captureState(): string {
+  const refTree = getRevListGitTree({
+    useMemoizedResults: false,
+    direction: "parents",
+  });
+  const branchToRefMapping = getBranchToRefMapping();
+
+  const metadata: Record<string, string> = {};
+  MetadataRef.allMetadataRefs().forEach((ref) => {
+    metadata[ref._branchName] = JSON.stringify(ref.read());
+  });
+
+  const state: stateT = {
+    refTree,
+    branchToRefMapping,
+    userConfig: JSON.stringify(userConfig._data),
+    repoConfig: JSON.stringify(repoConfig._data),
+    metadata,
+  };
+
+  return JSON.stringify(state, null, 2);
+}
+
+export function recreateState(stateJson: string): string {
+  const state = JSON.parse(stateJson) as stateT;
+  const refMappingsOldToNew: Record<string, string> = {};
+
+  const tmpDir = createTmpGitDir();
+  process.chdir(tmpDir);
+
+  logInfo(`Creating ${Object.keys(state.refTree).length} commits`);
+  recreateCommits({ refTree: state.refTree, refMappingsOldToNew });
+
+  logInfo(`Creating ${Object.keys(state.branchToRefMapping).length} branches`);
+  createBranches({
+    branchToRefMapping: state.branchToRefMapping,
+    refMappingsOldToNew,
+  });
+
+  logInfo(`Creating the repo config`);
+  fs.writeFileSync(
+    path.join(tmpDir, "/.git/.graphite_repo_config"),
+    state.repoConfig
+  );
+
+  logInfo(`Creating the metadata`);
+  createMetadata({ metadata: state.metadata, tmpDir });
+
+  return tmpDir;
+}
+
+function createMetadata(opts: {
+  metadata: Record<string, string>;
+  tmpDir: string;
+}) {
+  fs.mkdirSync(`${opts.tmpDir}/.git/refs/branch-metadata`);
+  Object.keys(opts.metadata).forEach((branchName) => {
+    const metaSha = gpExecSync({
+      command: `git hash-object -w --stdin`,
+      options: {
+        input: opts.metadata[branchName],
+      },
+    }).toString();
+    fs.writeFileSync(
+      `${opts.tmpDir}/.git/refs/branch-metadata/${branchName}`,
+      metaSha
+    );
+  });
+}
+
+function createBranches(opts: {
+  branchToRefMapping: Record<string, string>;
+  refMappingsOldToNew: Record<string, string>;
+}): void {
+  const curBranch = currentBranchPrecondition();
+  Object.keys(opts.branchToRefMapping).forEach((branch) => {
+    const originalRef =
+      opts.refMappingsOldToNew[opts.branchToRefMapping[branch]];
+    if (branch != curBranch.name)
+      gpExecSync({ command: `git branch -f ${branch} ${originalRef}` });
+  });
+}
+
+function recreateCommits(opts: {
+  refTree: Record<string, string[]>;
+  refMappingsOldToNew: Record<string, string>;
+}): void {
+  const treeObjectId = getTreeObjectId();
+  const commitsToCreate: string[] = commitRefsWithNoParents(opts.refTree);
+  const firstCommitRef = gpExecSync({ command: `git rev-parse HEAD` });
+  while (commitsToCreate.length > 0) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const originalCommitRef: string = commitsToCreate.shift()!;
+    const originalParents = opts.refTree[originalCommitRef] || [];
+    const newCommitRef = gpExecSync({
+      command: `git commit-tree ${treeObjectId} -m "${originalCommitRef}" ${
+        originalParents.length === 0
+          ? `-p ${firstCommitRef}`
+          : originalParents
+              .map((p) => opts.refMappingsOldToNew[p])
+              .map((newParentRef) => `-p ${newParentRef}`)
+              .join(" ")
+      }`,
+    })
+      .toString()
+      .trim();
+
+    // Save mapping so we can later associate branches.
+    opts.refMappingsOldToNew[originalCommitRef] = newCommitRef;
+
+    // Find all commits with this as parent, and enque them for creation.
+    Object.keys(opts.refTree).forEach((potentialChildRef) => {
+      const parents = opts.refTree[potentialChildRef];
+      if (parents.includes(originalCommitRef)) {
+        commitsToCreate.push(potentialChildRef);
+      }
+    });
+  }
+}
+
+function createTmpGitDir(): string {
+  const tmpDir = tmp.dirSync().name;
+  logInfo(`Creating tmp repo`);
+  gpExecSync({ command: `git -C ${tmpDir} init -b "main"` });
+  gpExecSync({
+    command: `cd ${tmpDir} && echo "first" > first.txt && git add first.txt && git commit -m "first"`,
+  });
+  return tmpDir;
+}
+
+function commitRefsWithNoParents(refTree: Record<string, string[]>): string[] {
+  // Create commits for each ref
+  const allRefs: string[] = [
+    ...new Set(Object.keys(refTree).concat.apply([], Object.values(refTree))),
+  ];
+  return allRefs.filter(
+    (ref) => refTree[ref] === undefined || refTree[ref].length === 0
+  );
+}
+
+function getTreeObjectId(): string {
+  return gpExecSync({
+    command: `git cat-file -p HEAD | grep tree | awk '{print $2}'`,
+  })
+    .toString()
+    .trim();
+}

--- a/src/lib/git-refs/branch_ref.ts
+++ b/src/lib/git-refs/branch_ref.ts
@@ -32,6 +32,14 @@ function refreshRefsCache(): void {
     refToBranches: memoizedRefToBranches,
   });
 }
+
+export function getBranchToRefMapping(): Record<string, string> {
+  if (!cache.getBranchToRef()) {
+    refreshRefsCache();
+  }
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return cache.getBranchToRef()!;
+}
 export function getRef(branch: Branch): string {
   if (!branch.shouldUseMemoizedResults || !cache.getBranchToRef()) {
     refreshRefsCache();

--- a/src/lib/git-refs/branch_relations.ts
+++ b/src/lib/git-refs/branch_relations.ts
@@ -61,7 +61,7 @@ export function getBranchChildrenOrParentsFromGit(
   );
 }
 
-function getRevListGitTree(opts: {
+export function getRevListGitTree(opts: {
   useMemoizedResults: boolean;
   direction: "parents" | "children";
 }): Record<string, string[]> {

--- a/src/lib/utils/git_repo.ts
+++ b/src/lib/utils/git_repo.ts
@@ -5,8 +5,14 @@ import { rebaseInProgress } from "./";
 const TEXT_FILE_NAME = "test.txt";
 export default class GitRepo {
   dir: string;
-  constructor(dir: string, opts?: { repoUrl: string }) {
+  constructor(
+    dir: string,
+    opts?: { existingRepo?: boolean; repoUrl?: string }
+  ) {
     this.dir = dir;
+    if (opts?.existingRepo) {
+      return;
+    }
     if (opts?.repoUrl) {
       execSync(`git clone ${opts.repoUrl} ${dir}`);
     } else {

--- a/test/fast/commands/feedback/debug_context.test.ts
+++ b/test/fast/commands/feedback/debug_context.test.ts
@@ -1,0 +1,49 @@
+import { expect } from "chai";
+import fs from "fs-extra";
+import { GitRepo } from "../../../../src/lib/utils";
+import { TrailingProdScene } from "../../../lib/scenes";
+import { configureTest } from "../../../lib/utils";
+
+for (const scene of [new TrailingProdScene()]) {
+  describe(`(${scene}): feedback debug-context`, function () {
+    configureTest(this, scene);
+
+    it("Can create debug-context", () => {
+      expect(() =>
+        scene.repo.execCliCommand(`feedback debug-context`)
+      ).to.not.throw(Error);
+    });
+
+    it("Can recreate a tmp repo based on debug context", () => {
+      scene.repo.createChange("a", "a");
+      scene.repo.execCliCommand(`branch create a -m "a"`);
+
+      scene.repo.createChange("b", "b");
+      scene.repo.execCliCommand(`branch create b -m "b"`);
+
+      const context = scene.repo.execCliCommandAndGetOutput(
+        `feedback debug-context`
+      );
+
+      const outputLines = scene.repo
+        .execCliCommandAndGetOutput(
+          `feedback debug-context --recreate '${context}'`
+        )
+        .toString()
+        .trim()
+        .split("\n");
+
+      const tmpDir = outputLines[outputLines.length - 1];
+
+      const newRepo = new GitRepo(tmpDir);
+      newRepo.checkoutBranch("b");
+      expect(newRepo.currentBranchName()).to.eq("b");
+
+      newRepo.execCliCommand(`bp`);
+      expect(newRepo.currentBranchName()).to.eq("a");
+
+      fs.emptyDirSync(tmpDir);
+      fs.removeSync(tmpDir);
+    });
+  });
+}


### PR DESCRIPTION
**Context:**
Create a command for printing debug-context, as well as recreating that debug state in a tmp dir. This will be used for recreating buggy state reported by users.


example of captured output:
```
graphite-cli on  gf--feat_feedback_include_optional_debug [$] is 📦 v0.13.1 via ⬢ v15.14.0 took 6s 
➜ gt feedback debug-context

{
  "refTree": {
    "238b0c7d213c069298ab999b7e49ad95efa01e47": [
      "40e3da7d76e361aef643690257c8d6b34893b31a"
    ],
    "40e3da7d76e361aef643690257c8d6b34893b31a": [
      "62dee0ad44dfe5acf27b028ca24f7105c5db24f7"
    ],
    "62dee0ad44dfe5acf27b028ca24f7105c5db24f7": [
      "7443950555f28e449c21b75ea80ed8c5cebe4461"
    ],
    "b7105dfa9d8d4ff2a18343b79c76e6767e500b0c": [
      "7443950555f28e449c21b75ea80ed8c5cebe4461"
    ],
    "4ba51fa3fc886204c3e07f804f34c2369051033d": [
      "7443950555f28e449c21b75ea80ed8c5cebe4461"
    ],
    "cc36a3ec05ba590c3e0352769c3f491c28834392": [
      "2031ffd20826a59d29a422815a297c014463ed15"
    ],
    "2031ffd20826a59d29a422815a297c014463ed15": [
      "7443950555f28e449c21b75ea80ed8c5cebe4461"
    ],
    "47d39ebc0c03c0a27589bd96c2c5858fae97a06e": [
      "7443950555f28e449c21b75ea80ed8c5cebe4461"
    ],
    "f663fd182d23f5474864b4ff5471946f8076fb4c": [
      "7443950555f28e449c21b75ea80ed8c5cebe4461"
    ],
    "7443950555f28e449c21b75ea80ed8c5cebe4461": [
      "00370137f584d0e58da877d5eb0a7ee8399a4eea"
    ]
  },
  "branchToRefMapping": {
    "gf--08-20-test_rust_start_experimenting": "f663fd182d23f5474864b4ff5471946f8076fb4c",
    "gf--09-01-refactor_feedback_move_into_fo": "62dee0ad44dfe5acf27b028ca24f7105c5db24f7",
    "gf--feat_feedback_include_optional_debug": "238b0c7d213c069298ab999b7e49ad95efa01e47",
    "gf--feat_state_capture_command_to_summar": "40e3da7d76e361aef643690257c8d6b34893b31a",
    "gf--fix_cancel_improve_logging_when_kill": "4ba51fa3fc886204c3e07f804f34c2369051033d",
    "gf--fix_cycles_disallow_meta_parent_cycl": "47d39ebc0c03c0a27589bd96c2c5858fae97a06e",
    "gf--fix_trunk_ignore_sibling_branches_co": "b7105dfa9d8d4ff2a18343b79c76e6767e500b0c",
    "gf--sync_revert_revert": "cc36a3ec05ba590c3e0352769c3f491c28834392",
    "main": "7443950555f28e449c21b75ea80ed8c5cebe4461"
  },
  "userConfig": "{\"authToken\":\"b3v36mhGytgDVkGK5FVFn5qR3VselXCuOCmobnULTsdngvyywfZcZ9DQypHe\",\"branchPrefix\":\"gf--\"}",
  "repoConfig": "{\"trunk\":\"main\",\"ignoreBranches\":[\"prod\"],\"lastFetchedPRInfoMs\":1630535014434}",
  "metadata": {
    "gf--08-20-test_rust_start_experimenting": "{\"parentBranchName\":\"main\",\"prevRef\":\"080a2df3e76a5f30cd3e9ea3dc8af2848a195414\",\"prInfo\":{\"number\":273,\"base\":\"main\",\"url\":\"https://github.com/screenplaydev/graphite-cli/pull/273\",\"state\":\"CLOSED\",\"title\":\"test(rust): start experimenting\",\"reviewDecision\":\"REVIEW_REQUIRED\",\"isDraft\":false}}",
    "gf--09-01-refactor_feedback_move_into_fo": "{\"parentBranchName\":\"main\",\"prInfo\":{\"number\":317,\"url\":\"https://github.com/screenplaydev/graphite-cli/pull/317\",\"base\":\"main\"}}",
    "gf--feat_feedback_include_optional_debug": "{\"parentBranchName\":\"gf--feat_state_capture_command_to_summar\",\"prevRef\":\"4b938e4d3dbf79950a76c078b5d371aabef7f64e\",\"prInfo\":{\"number\":316,\"url\":\"https://github.com/screenplaydev/graphite-cli/pull/316\",\"base\":\"gf--feat_state_capture_command_to_summar\"}}",
    "gf--feat_state_capture_command_to_summar": "{\"parentBranchName\":\"gf--09-01-refactor_feedback_move_into_fo\",\"prInfo\":{\"number\":318,\"url\":\"https://github.com/screenplaydev/graphite-cli/pull/318\",\"base\":\"gf--09-01-refactor_feedback_move_into_fo\"}}",
    "gf--fix_cancel_improve_logging_when_kill": "{\"parentBranchName\":\"main\",\"prInfo\":{\"number\":312,\"base\":\"main\",\"url\":\"https://github.com/screenplaydev/graphite-cli/pull/312\",\"state\":\"OPEN\",\"title\":\"fix(cancel): improve logging when killing during prompt\",\"reviewDecision\":\"REVIEW_REQUIRED\",\"isDraft\":false}}",
    "gf--fix_cycles_disallow_meta_parent_cycl": "{\"parentBranchName\":\"main\",\"prInfo\":{\"number\":238,\"base\":\"main\",\"url\":\"https://github.com/screenplaydev/graphite-cli/pull/238\",\"state\":\"OPEN\",\"title\":\"fix(cycles): disallow meta parent cycles\",\"reviewDecision\":\"APPROVED\",\"isDraft\":false},\"prevRef\":\"f0e3e784cd0bb9a691f84ae5e933ffc650bb02a3\"}",
    "gf--fix_trunk_ignore_sibling_branches_co": "{\"parentBranchName\":\"main\",\"prInfo\":{\"number\":313,\"base\":\"main\",\"url\":\"https://github.com/screenplaydev/graphite-cli/pull/313\",\"state\":\"OPEN\",\"title\":\"fix(trunk): ignore sibling branches correctly\",\"reviewDecision\":\"REVIEW_REQUIRED\",\"isDraft\":false}}",
    "gf--sync_revert_revert": "{\"parentBranchName\":\"main\",\"prInfo\":{\"number\":311,\"base\":\"main\",\"url\":\"https://github.com/screenplaydev/graphite-cli/pull/311\",\"state\":\"OPEN\",\"title\":\"Merge gf--sync_revert_revert into main\",\"reviewDecision\":\"REVIEW_REQUIRED\",\"isDraft\":false}}"
  }
}
```
