### PR TITLE
Add command to link branches to PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/screenplaydev/screenplay-cli",
   "private": true,
   "dependencies": {
-    "@screenplaydev/graphite-cli-routes": "0.9.0",
+    "@screenplaydev/graphite-cli-routes": "0.10.0",
     "@screenplaydev/retype": "^0.2.0",
     "@screenplaydev/retyped-routes": "^0.1.0",
     "chalk": "^4.1.0",

--- a/src/commands/branch-commands/pr.ts
+++ b/src/commands/branch-commands/pr.ts
@@ -1,0 +1,43 @@
+import yargs from "yargs";
+import { currentBranchPrecondition } from "../../lib/preconditions";
+import { syncPRInfoForBranches } from "../../lib/sync/pr_info";
+import { profile } from "../../lib/telemetry";
+import { getTrunk, logInfo } from "../../lib/utils";
+
+const args = {
+  set: {
+    type: "number",
+    positional: true,
+    demandOption: true,
+    describe: "Override the PR number associated with the current branch.",
+  },
+} as const;
+type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
+
+export const aliases = [];
+export const command = "pr";
+export const description =
+  "Get the current branch with the provided GitHub PR number for the current repo.";
+export const builder = args;
+export const handler = async (argv: argsT): Promise<void> => {
+  return profile(argv, async () => {
+    const branch = currentBranchPrecondition();
+    if (argv.set) {
+      // All branches associated with PRs must have a base; if there is no base
+      // detected, we automatically defer to trunk.
+      const base = branch.getParentFromMeta()?.name ?? getTrunk().name;
+
+      branch.setPRInfo({
+        number: argv.set,
+        base: base,
+      });
+
+      await syncPRInfoForBranches([branch]);
+    } else {
+      logInfo(
+        branch.getPRInfo()?.number.toString() ??
+          "No PR associated with this branch"
+      );
+    }
+  });
+};

--- a/src/lib/sync/pr_info.ts
+++ b/src/lib/sync/pr_info.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import graphiteCLIRoutes from "@screenplaydev/graphite-cli-routes";
+import { request } from "@screenplaydev/retyped-routes";
+import { logError } from "../../lib/utils";
+import Branch from "../../wrapper-classes/branch";
+import { API_SERVER } from "../api";
+import { repoConfig, userConfig } from "../config";
+
+/**
+ * TODO (nicholasyan): for now, this just syncs info for branches with existing
+ * PR info. In the future, we can extend this method to query GitHub for PRs
+ * associated with branch heads that don't have associated PR info.
+ */
+export async function syncPRInfoForBranches(branches: Branch[]): Promise<void> {
+  const authToken = userConfig.getAuthToken();
+  if (authToken === undefined) {
+    return;
+  }
+
+  const repoName = repoConfig.getRepoName();
+  const repoOwner = repoConfig.getRepoOwner();
+
+  const prNumsToBranches: { [key: number]: Branch } = {};
+  branches.forEach((branch) => {
+    const prInfo = branch.getPRInfo();
+    if (prInfo === undefined) {
+      return;
+    }
+    prNumsToBranches[prInfo.number] = branch;
+  });
+
+  const response = await request.requestWithArgs(
+    API_SERVER,
+    graphiteCLIRoutes.pullRequestInfo,
+    {
+      authToken: authToken,
+      repoName: repoName,
+      repoOwner: repoOwner,
+      prNumbers: Object.keys(prNumsToBranches).map((num) => parseInt(num)),
+    }
+  );
+
+  if (response._response.status === 200) {
+    await Promise.all(
+      response.prs.map(async (pr) => {
+        const branch = prNumsToBranches[pr.prNumber];
+        branch.setPRInfo({
+          number: pr.prNumber,
+          base: pr.baseRefName,
+          url: pr.url,
+          state: pr.state,
+          title: pr.title,
+          reviewDecision: pr.reviewDecision ?? undefined,
+          isDraft: pr.isDraft,
+        });
+
+        if (branch.name !== pr.headRefName) {
+          logError(
+            `PR ${pr.prNumber} is associated with ${pr.headRefName} on GitHub, but branch ${branch.name} locally. Please rename the local branch (\`gt branch rename\`) to match the remote branch associated with the PR. (While ${branch.name} is misaligned with GitHub, you cannot use \`gt submit\` on it.)`
+          );
+        }
+      })
+    );
+  }
+}

--- a/src/wrapper-classes/metadata_ref.ts
+++ b/src/wrapper-classes/metadata_ref.ts
@@ -12,7 +12,7 @@ export type TBranchPRReviewDecision =
 export type TBranchPRInfo = {
   number: number;
   base: string;
-  url: string;
+  url?: string;
   title?: string;
   state?: TBranchPRState;
   reviewDecision?: TBranchPRReviewDecision;

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,14 +294,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@screenplaydev/graphite-cli-routes@npm:0.9.0":
-  version: 0.9.0
-  resolution: "@screenplaydev/graphite-cli-routes@npm:0.9.0"
+"@screenplaydev/graphite-cli-routes@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@screenplaydev/graphite-cli-routes@npm:0.10.0"
   dependencies:
     "@screenplaydev/retype": ^0.2.0
     "@screenplaydev/retyped-routes": ^0.1.0
     "@types/node": ^14.14.37
-  checksum: e68522efc84837c438d6b9d87e082aa60231f7e786f3bf7a708f6f6142a61b37f4dc1ba8331c9654d96e03ea1ab269509838dcf50cb27166141c7a6c475f6eb1
+  checksum: 74ab6c3c7477c9e54f31d0250e00248be7122d1e57c6d8172aec5e6a3e3d990d72f79335687b82deaa1f7dec5125ed8b885b74508f41bb0268ef856fe38a4823
   languageName: node
   linkType: hard
 
@@ -2265,7 +2265,7 @@ fsevents@~2.3.1:
   dependencies:
     "@commitlint/cli": ^13.1.0
     "@commitlint/config-conventional": ^13.1.0
-    "@screenplaydev/graphite-cli-routes": 0.9.0
+    "@screenplaydev/graphite-cli-routes": 0.10.0
     "@screenplaydev/retype": ^0.2.0
     "@screenplaydev/retyped-routes": ^0.1.0
     "@types/chai": ^4.2.14


### PR DESCRIPTION
**Context:**

Multiple users in the past week have ended up in a state where they submitted a PR without Graphite and then later worked on a stack with Graphite — and wanted to let Graphite know about the existing PR.

**Changes In This Pull Request:**


This PR adds a command, `gt branch set-pr`, that allows users to manually link a given branch to a PR. The up-level here is to bake functionality into the sync command that automatically links outstanding PRs to branches given their branch names, but I'm adding this as a temporary stopgap while I go and implement that.

One corner case introduced here — users can now link local branches to PRs with a different head ref name. While this made sense in Phabricator land, it makes little sense here now since 1) the local branch is being pushed to a different remote branch 2) GitHub doesn't allow you to change PR head branches after-the-fact. As a result, now that we allow users to get themselves into this situation, we also try and detect it where possible and then throw an error in these cases.

**Test Plan:**

Tested locally against this branch, disassociating PR info and then re-linking it via this command.

