### PR TITLE
[Repo Sync] Don't resubmit trunk or branches without bases

### DIFF
--- a/src/actions/sync.ts
+++ b/src/actions/sync.ts
@@ -147,9 +147,13 @@ function cleanDanglingMetadata(): void {
 
 async function resubmitBranchesWithNewBases(force: boolean): Promise<void> {
   const needsResubmission: Branch[] = [];
-  Branch.allBranches().forEach((b) => {
-    const base = b.getPRInfo()?.base;
-    if (base && base !== b.getParentFromMeta()?.name) {
+  Branch.allBranchesWithFilter({
+    filter: (b) => !b.isTrunk() && b.getParentFromMeta() !== undefined,
+  }).forEach((b) => {
+    const currentBase = b.getParentFromMeta()?.name;
+    const githubBase = b.getPRInfo()?.base;
+
+    if (githubBase && githubBase !== currentBase) {
       needsResubmission.push(b);
     }
   });


### PR DESCRIPTION
**Context:**

Noticed repo sync was trying to resubmit trunk and branches without bases in my local test repo, causing errors.

**Changes In This Pull Request:**

Filter these out.

**Test Plan:**

Running repo sync in my local repo ignores these branches now.
