### PR TITLE
[Repo Sync] Catch dangling branches

### DIFF
--- a/src/commands/repo-commands/repo_sync.ts
+++ b/src/commands/repo-commands/repo_sync.ts
@@ -31,6 +31,13 @@ const args = {
     type: "boolean",
     alias: "p",
   },
+  "show-dangling": {
+    describe: `Show prompts to fix dangling branches (branches for whose parent is unknown to Graphite).`,
+    demandOption: false,
+    default: true,
+    type: "boolean",
+    alias: "s",
+  },
 } as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
@@ -46,6 +53,7 @@ export const handler = async (argv: argsT): Promise<void> => {
       force: argv.force,
       resubmit: argv.resubmit,
       delete: argv.delete,
+      fixDanglingBranches: argv["show-dangling"],
     });
   });
 };


### PR DESCRIPTION
**Context:**

When the user runs `repo sync`, we can also upsell them on fixing any dangling branches found in their repo. This also then allows us to check whether these dangling branches should be deleted or re-submitted.

**Changes In This Pull Request:**

Adds a step to repo sync to flag dangling branches and suggest fixing them back onto trunk.

**Test Plan:**

tested locally

