### PR TITLE
[Repo Sync] Add options to skip delete or resubmit

### DIFF
--- a/src/actions/sync.ts
+++ b/src/actions/sync.ts
@@ -27,6 +27,8 @@ import { saveBranchPRInfo, submitPRsForBranches } from "./submit";
 export async function syncAction(opts: {
   pull: boolean;
   force: boolean;
+  delete: boolean;
+  resubmit: boolean;
 }): Promise<void> {
   if (uncommittedChanges()) {
     throw new PreconditionsFailedError("Cannot sync with uncommitted changes");
@@ -42,9 +44,14 @@ export async function syncAction(opts: {
     });
   }
 
-  await deleteMergedBranches(opts.force);
+  if (opts.delete) {
+    await deleteMergedBranches(opts.force);
+  }
+  if (opts.resubmit) {
+    await resubmitBranchesWithNewBases(opts.force);
+  }
+
   checkoutBranch(Branch.exists(oldBranch.name) ? oldBranch.name : trunk);
-  await resubmitBranchesWithNewBases(opts.force);
   cleanDanglingMetadata();
 }
 

--- a/src/commands/repo-commands/repo_sync.ts
+++ b/src/commands/repo-commands/repo_sync.ts
@@ -3,8 +3,22 @@ import { syncAction } from "../../actions/sync";
 import { profile } from "../../lib/telemetry";
 
 const args = {
+  delete: {
+    describe: `Delete branches which have been merged.`,
+    demandOption: false,
+    default: true,
+    type: "boolean",
+    alias: "d",
+  },
+  resubmit: {
+    describe: `Re-submit branches whose merge bases have changed locally and now differ from their PRs.`,
+    demandOption: false,
+    default: true,
+    type: "boolean",
+    alias: "r",
+  },
   force: {
-    describe: `Don't prompt you to confirm when a branch will be deleted.`,
+    describe: `Don't prompt you to confirm when a branch will be deleted or re-submitted.`,
     demandOption: false,
     default: false,
     type: "boolean",
@@ -30,6 +44,8 @@ export const handler = async (argv: argsT): Promise<void> => {
     await syncAction({
       pull: argv.pull,
       force: argv.force,
+      resubmit: argv.resubmit,
+      delete: argv.delete,
     });
   });
 };


### PR DESCRIPTION
**Context:**

As titled.

**Changes In This Pull Request:**

Adding options to repo sync to allow users (or tests) to skip the delete and/or resubmission portions of the command. This will be used in tests in the next PR.

**Test Plan:**

yarn build

