### PR TITLE
[Sync PR] Update branch sync-pr to no longer need PR number

### DIFF
--- a/src/actions/print_stack.ts
+++ b/src/actions/print_stack.ts
@@ -120,7 +120,10 @@ function getBranchInfo(branch: Branch, config: TPrintStackConfig): string[] {
   return branchInfoLines;
 }
 
-function getBranchTitle(branch: Branch, config: TPrintStackConfig): string {
+export function getBranchTitle(
+  branch: Branch,
+  config: TPrintStackConfig
+): string {
   const prInfo = branch.getPRInfo();
   const branchName =
     config.currentBranch?.name === branch.name

--- a/src/commands/branch-commands/pr.ts
+++ b/src/commands/branch-commands/pr.ts
@@ -1,43 +1,50 @@
+import chalk from "chalk";
 import yargs from "yargs";
+import { getBranchTitle } from "../../actions/print_stack";
+import { repoConfig } from "../../lib/config";
 import { currentBranchPrecondition } from "../../lib/preconditions";
 import { syncPRInfoForBranches } from "../../lib/sync/pr_info";
 import { profile } from "../../lib/telemetry";
-import { getTrunk, logInfo } from "../../lib/utils";
+import { logError } from "../../lib/utils";
 
-const args = {
-  set: {
-    type: "number",
-    positional: true,
-    demandOption: true,
-    describe: "Override the PR number associated with the current branch.",
-  },
-} as const;
+const args = {} as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
 export const aliases = [];
-export const command = "pr";
+export const command = "sync";
 export const description =
-  "Get the current branch with the provided GitHub PR number for the current repo.";
+  "Fetch GitHub PR information for the current branch.";
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, async () => {
     const branch = currentBranchPrecondition();
-    if (argv.set) {
-      // All branches associated with PRs must have a base; if there is no base
-      // detected, we automatically defer to trunk.
-      const base = branch.getParentFromMeta()?.name ?? getTrunk().name;
+    await syncPRInfoForBranches([branch]);
 
-      branch.setPRInfo({
-        number: argv.set,
-        base: base,
-      });
-
-      await syncPRInfoForBranches([branch]);
-    } else {
-      logInfo(
-        branch.getPRInfo()?.number.toString() ??
-          "No PR associated with this branch"
+    const prInfo = branch.getPRInfo();
+    if (prInfo === undefined) {
+      logError(
+        `Could not find associated PR. Please double-check that a PR exists on GitHub in repo ${chalk.bold(
+          repoConfig.getRepoName()
+        )} for the branch ${chalk.bold(branch.name)}.`
       );
+      return;
+    }
+
+    console.log(
+      getBranchTitle(branch, {
+        currentBranch: null,
+        offTrunk: false,
+      })
+    );
+
+    const prTitle = prInfo.title;
+    if (prTitle !== undefined) {
+      console.log(prTitle);
+    }
+
+    const prURL = prInfo.url;
+    if (prURL !== undefined) {
+      console.log(prURL);
     }
   });
 };


### PR DESCRIPTION
**Context:**

See previous PR.

**Changes In This Pull Request:**

Now that we don't need a PR number to find a pull request, we can also make our branch sync-pr command more developer friendly. You can just run it, force-fetching (and updating) any PR information about the current branch — without needing to supply a PR number.

I've also edited the return format to print out the linked PR in the same format as our log output.

**Test Plan:**

Unlinked/linked a PR, attempted to link a PR without an associated branch.

