### PR TITLE
[Submit] Ignore already-merged branches

### DIFF
--- a/src/actions/submit.ts
+++ b/src/actions/submit.ts
@@ -12,18 +12,18 @@ import {
   ExitFailedError,
   KilledError,
   PreconditionsFailedError,
-  ValidationFailedError,
+  ValidationFailedError
 } from "../lib/errors";
 import {
   cliAuthPrecondition,
-  currentBranchPrecondition,
+  currentBranchPrecondition
 } from "../lib/preconditions";
 import {
   gpExecSync,
   logError,
   logInfo,
   logNewline,
-  logSuccess,
+  logSuccess
 } from "../lib/utils";
 import { getDefaultEditor } from "../lib/utils/default_editor";
 import { getPRTemplate } from "../lib/utils/pr_templates";
@@ -171,6 +171,10 @@ export async function submitPRsForBranches(args: {
     typeof graphiteCLIRoutes.submitPullRequests.params
   >["prs"] = [];
   for (const branch of args.branches) {
+    if (branch.getPRInfo()?.state === "MERGED") {
+      continue;
+    }
+
     // The branch here should always have a parent - above, the branches we've
     // gathered should exclude trunk which ensures that every branch we're submitting
     // a PR for has a valid parent.


### PR DESCRIPTION
**Context:**

We see a fair number of submit errors where submit has been called on a PR that was already merged.

**Changes In This Pull Request:**

If we know a PR has already been merged (e.g. through background updates or a call to repo sync), we skip it when the user calls submit. 

Note that we don't skip PRs which were just closed (without merging).

**Test Plan:**

yarn build

