### PR TITLE
[Branch] Add parent --reset command

### DIFF
--- a/src/commands/branch-commands/parent.ts
+++ b/src/commands/branch-commands/parent.ts
@@ -15,6 +15,11 @@ const args = {
       "Manually set the stack parent of the current branch. This operation only modifies Graphite metadata and does not rebase any branches.",
     required: false,
   },
+  reset: {
+    type: "boolean",
+    describe: "Disassociate the branch from its current tracked parent.",
+    required: false,
+  },
 } as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
@@ -27,6 +32,8 @@ export const handler = async (argv: argsT): Promise<void> => {
     const branch = currentBranchPrecondition();
     if (argv.set) {
       setParent(branch, argv.set);
+    } else if (argv.reset) {
+      branch.resetParentBranch();
     } else {
       const parent = branch.getParentFromMeta();
       if (parent) {

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -191,6 +191,12 @@ export default class Branch {
     this.writeMeta(meta);
   }
 
+  public resetParentBranch(): void {
+    const meta: TMeta = this.getMeta() || {};
+    meta.parentBranchName = undefined;
+    this.writeMeta(meta);
+  }
+
   public setMetaPrevRef(prevRef: string): void {
     const meta: TMeta = this.getMeta() || {};
     meta.prevRef = prevRef;


### PR DESCRIPTION
**Context:**

Earlier today, with the new logic in `repo sync` to fix dangling branches, I accidentally affixed a branch I wanted ignored to trunk.

I think there's 2 fixes necessary here:
* add a command that can reset a parent to `undefined`
* add a larger suite of options when fixing dangling branches

**Changes In This Pull Request:**

This PR addresses the first. The next PR addresses the second.

**Test Plan:**

reset a branch's parent locally; verified through `gt branch parent`

