### PR TITLE
[PR Info] Don't fetch PR info for trunk

### DIFF
--- a/src/lib/sync/pr_info.ts
+++ b/src/lib/sync/pr_info.ts
@@ -28,7 +28,9 @@ export async function syncPRInfoForBranches(branches: Branch[]): Promise<void> {
       repoName: repoName,
       repoOwner: repoOwner,
       prNumbers: [],
-      prHeadRefNames: branches.map((branch) => branch.name),
+      prHeadRefNames: branches
+        .filter((branch) => !branch.isTrunk())
+        .map((branch) => branch.name),
     }
   );
 


### PR DESCRIPTION
**Context:**

Addressing some feedback that after our most recent changes to repo sync, that one user's trunk branch was pulling in PR info and was showing as "abandoned." My theory here is that the trunk branch has a long-lived trailing branch and that at some point, a PR that merged trunk into the trailing branch was abandoned.

**Changes In This Pull Request:**

Special casing by a single branch (even if it is trunk) doesn't feel great, but I couldn't think of a better solution here. So in this PR, we just make sure that when we're fetching PR info from our PR info endpoint, we don't request any info for trunk.

**Test Plan:**

yarn build

