### PR TITLE
[Dangling Branches] Add more fix options

### DIFF
--- a/src/lib/config/repo_config.ts
+++ b/src/lib/config/repo_config.ts
@@ -72,6 +72,11 @@ class RepoConfig {
     return this._data.trunk;
   }
 
+  public addIgnoredBranches(ignoreBranchesToAdd: string[]): void {
+    const currentIgnoredBranches = this.getIgnoreBranches();
+    this.setIgnoreBranches(ignoreBranchesToAdd.concat(currentIgnoredBranches));
+  }
+
   public setIgnoreBranches(ignoreBranches: string[]): void {
     this._data.ignoreBranches = ignoreBranches;
     this.save();


### PR DESCRIPTION
**Context:**

Earlier today, with the new logic in `repo sync` to fix dangling branches, I accidentally affixed a branch I wanted ignored to trunk.

I think there's 2 fixes necessary here:
* add a command that can reset a parent to `undefined`
* add a larger suite of options when fixing dangling branches

**Changes In This Pull Request:**

This PR addresses the second. (The previous PR addressed the first.)

**Test Plan:**

<img width="620" alt="Screen Shot 2021-09-20 at 2 22 51 PM" src="https://user-images.githubusercontent.com/9063972/134079816-6e278c43-a73a-4308-8fc4-d6f00b003dba.png">



