### PR TITLE
[Sync] Add --reset to remove branch PR info

### DIFF
--- a/src/commands/branch-commands/sync.ts
+++ b/src/commands/branch-commands/sync.ts
@@ -7,7 +7,13 @@ import { syncPRInfoForBranches } from "../../lib/sync/pr_info";
 import { profile } from "../../lib/telemetry";
 import { logError } from "../../lib/utils";
 
-const args = {} as const;
+const args = {
+  reset: {
+    describe: `Removes current GitHub PR information linked to the current branch`,
+    demandOption: false,
+    type: "boolean",
+  },
+} as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
 export const aliases = [];
@@ -18,6 +24,12 @@ export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, async () => {
     const branch = currentBranchPrecondition();
+
+    if (argv.reset) {
+      branch.clearPRInfo();
+      return;
+    }
+
     await syncPRInfoForBranches([branch]);
 
     const prInfo = branch.getPRInfo();

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -393,6 +393,12 @@ export default class Branch {
     this.writeMeta(meta);
   }
 
+  public clearPRInfo(): void {
+    const meta: TMeta = this.getMeta() || {};
+    meta.prInfo = undefined;
+    this.writeMeta(meta);
+  }
+
   public getPRInfo(): TBranchPRInfo | undefined {
     return this.getMeta()?.prInfo;
   }


### PR DESCRIPTION
**Context:**

In #340 we added behavior to not sync PR info for trunk to fix the issue forward for the user who saw a "abandoned" trunk PR. I also want to give them a way to reset the PR info for their branch.

**Changes In This Pull Request:**

This PR introduces a `--reset` option (open to naming suggestions here) which clears the current PR info for a branch.

Note that we have lots of ways to re-fetch PR info for a branch, but this currently works nicely with them all:
* we fetch PR info in the background, but only do so if we know that the branch already was associated with a PR
* in `repo sync`, we fetch PR info for all branches — but in the user's case, we've special-cased trunk to rule it out
  * note that this does mean that you can reset PR info, run `repo sync`, and see the PR info pop right up again; the idea in my mind here is that if you're unlinking PR info, it's likely because you want to resubmit the PR again immediately as a new PR

**Test Plan:**

unlinked a PR locally; verified through `gt log` that it's PR info was gone

