### PR TITLE
Branch autocomplete MVP

### DIFF
--- a/src/commands/autocomplete.ts
+++ b/src/commands/autocomplete.ts
@@ -28,8 +28,9 @@ yargs.completion("completion", (current, argv) => {
  */
 function getBranchArg(current: string, argv: Arguments): string | null {
   const currentCommand = argv["_"].join(" ");
+
   // gt branch checkout --branch <branch_name>
-  if ((currentCommand.includes("branch checkout") || argv["_"].includes("bc")) && "branch" in argv) {
+  if ((currentCommand.includes("branch checkout") || currentCommand.includes("b checkout")) && "branch" in argv) {
     // Because --branch is an option on the overall command, we need to check
     // the value of current to make sure that the branch argument is the
     // current argument being entered by the user.
@@ -40,11 +41,20 @@ function getBranchArg(current: string, argv: Arguments): string | null {
     }
   }
 
+  // gt bco
+  // Check membership in argv to ensure that "bco" is its own entry (and not
+  // a substring of another command). Since we're dealing with a positional,
+  // we also want to make sure that the current argument is the positional
+  // (position 3).
+  if (argv["_"].includes("bco") && argv["_"].length <= 3 && typeof current === "string") {
+    return current;
+  }
+
   // gt upstack onto <branch_name>
   if (currentCommand.includes("upstack onto") || currentCommand.includes("us onto")) {
-    // Since we're detailing with a positional, we want to make sure that the
-    // current argument being entered is in the desired position, i.e. position
-    // 4.
+    // Again, since we're detailing with a positional, we want to make sure
+    // that the current argument being entered is in the desired position,
+    // i.e. position 4.
     if (argv["_"].length <= 4 && typeof current === "string") {
       return current;
     }

--- a/src/commands/autocomplete.ts
+++ b/src/commands/autocomplete.ts
@@ -1,14 +1,7 @@
-import fs from "fs-extra";
-import os from "os";
-import path from "path";
 import yargs, { Arguments } from "yargs";
 import { Branch } from "../wrapper-classes";
 
-const CONFIG_NAME = "current";
-const CURRENT = path.join(os.homedir(), CONFIG_NAME);
-
 yargs.completion("completion", (current, argv) => {
-  fs.writeFileSync(CURRENT, argv["_"].join(" "));
   const branchArg = getBranchArg(current, argv);
   if (branchArg === null) {
     return;
@@ -34,8 +27,9 @@ yargs.completion("completion", (current, argv) => {
  * gt log => null
  */
 function getBranchArg(current: string, argv: Arguments): string | null {
+  const currentCommand = argv["_"].join(" ");
   // gt branch checkout --branch <branch_name>
-  if (argv["_"].join(" ").includes("branch checkout") && "branch" in argv) {
+  if ((currentCommand.includes("branch checkout") || argv["_"].includes("bc")) && "branch" in argv) {
     // Because --branch is an option on the overall command, we need to check
     // the value of current to make sure that the branch argument is the
     // current argument being entered by the user.
@@ -47,7 +41,7 @@ function getBranchArg(current: string, argv: Arguments): string | null {
   }
 
   // gt upstack onto <branch_name>
-  if (argv["_"].join(" ").includes("upstack onto")) {
+  if (currentCommand.includes("upstack onto") || currentCommand.includes("us onto")) {
     // Since we're detailing with a positional, we want to make sure that the
     // current argument being entered is in the desired position, i.e. position
     // 4.

--- a/src/commands/branch_autocomplete.ts
+++ b/src/commands/branch_autocomplete.ts
@@ -1,0 +1,60 @@
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import yargs, { Arguments } from "yargs";
+import { Branch } from "../wrapper-classes";
+
+const CONFIG_NAME = "current";
+const CURRENT = path.join(os.homedir(), CONFIG_NAME);
+
+yargs.completion("completion", (current, argv) => {
+  fs.writeFileSync(CURRENT, argv["_"].join(" "));
+  const branchArg = getBranchArg(current, argv);
+  if (branchArg === null) {
+    return;
+  }
+
+  return Branch.allBranchesWithFilter({
+    filter: (b) => b.name.startsWith(branchArg),
+  })
+    .map((b) => b.name)
+    .sort();
+});
+
+/**
+ * If the user is entering a branch argument, returns the current entered
+ * value. Else, returns null.
+ *
+ * e.g.
+ *
+ * gt branch checkout --branch ny--xyz => 'ny--xyz'
+ * gt branch checkout --branch => ''
+ *
+ * gt repo sync => null
+ * gt log => null
+ */
+function getBranchArg(current: string, argv: Arguments): string | null {
+  // gt branch checkout --branch <branch_name>
+  if (argv["_"].join(" ").includes("branch checkout") && "branch" in argv) {
+    // Because --branch is an option on the overall command, we need to check
+    // the value of current to make sure that the branch argument is the
+    // current argument being entered by the user.
+    if (current === "--branch") {
+      return "";
+    } else if (current === argv["branch"]) {
+      return current;
+    }
+  }
+
+  // gt upstack onto <branch_name>
+  if (argv["_"].join(" ").includes("upstack onto")) {
+    // Since we're detailing with a positional, we want to make sure that the
+    // current argument being entered is in the desired position, i.e. position
+    // 4.
+    if (argv["_"].length <= 4 && typeof current === "string") {
+      return current;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
**Changes In This Pull Request:**

This PR supports git branch autocomplete for our branch commands:
* `gt branch checkout --branch`
* `gt upstack onto`

We take advantage of the yargs [`completion` API](https://yargs.js.org/docs/#api-reference-completioncmd-description-fn) which creates a command that when run will spit out some bash to add to your `.bashrc`/`.zshrc`/`.zsh_profile` to hook into custom autocomplete logic.

This API isn't perfect — it looks like you have to specify the completion logic in one place, away from where the commands are defined so I'd imagine this is very brittle — but it does give us a good starting point.

@gregorymfoster also mentioned that there was a way to automatically run this script and add it to the relevant file in Homebrew, but I'll take a look into that in a separate Linear.

Lastly, there's an issue in the outputted bash for me (that yargs creates). I'm not sure if this is due to the fact that I'm aliasing Graphite locally, so I'll release this under the radar in 0.14.1 and test it myself.

**Test Plan:**

https://user-images.githubusercontent.com/9063972/134286018-2f7ee7ed-fca1-4963-8666-b549eeab9793.mov



