### PR TITLE
feat(branch): add support for gt branch top

### DIFF
--- a/src/actions/stack_traversal.ts
+++ b/src/actions/stack_traversal.ts
@@ -67,6 +67,30 @@ async function getNextBranch(
   }
 }
 
+
+function getTopBranch(
+    currentBranch: Branch,
+    interactive: boolean,
+): string| undefined {
+  let branch = currentBranch
+  let candidates = branch.getChildrenFromMeta();
+  let indent = 0
+  while (branch && candidates.length){
+    if (candidates.length === 1) {
+      logInfo(`${"  ".repeat(indent)}↳(${branch})`);
+      branch = candidates[0]
+      indent ++;
+    } else {
+      if (interactive) {
+        //TODO: deal with interactive option
+      }
+    }
+    candidates = branch.getChildrenFromMeta();
+  }
+  logInfo(`${"  ".repeat(indent)}↳(${chalk.cyan(branch)})`);
+  return branch?.name
+}
+
 export async function nextOrPrevAction(opts: {
   nextOrPrev: "next" | "prev";
   numSteps: number;
@@ -100,8 +124,21 @@ export async function bottomBranchAction(): Promise<void> {
   const bottomBranch = getBottomBranch(currentBranch);
   if (bottomBranch && bottomBranch != currentBranch.name) {
     execSync(`git checkout "${bottomBranch}"`, { stdio: "ignore" });
-    logInfo(
-        `${"  ".repeat(0)}↳(${chalk.cyan(bottomBranch)})`
-    );
+    logInfo(`Switched to ${bottomBranch}`);
+  } else {
+    logInfo("Already at the bottom most branch in the stack. Exiting.");
+  }
+}
+
+export async function topBranchAction(opts: {
+  interactive: boolean;
+}): Promise<void> {
+  const currentBranch = currentBranchPrecondition();
+  const topBranch = getTopBranch(currentBranch, opts.interactive);
+  if (topBranch && topBranch !== currentBranch.name) {
+    execSync(`git checkout "${topBranch}"`, { stdio: "ignore" });
+    logInfo(`Switched to ${topBranch}`);
+  } else {
+    logInfo("Already at the top most branch in the stack. Exiting.");
   }
 }

--- a/src/actions/stack_traversal.ts
+++ b/src/actions/stack_traversal.ts
@@ -68,10 +68,10 @@ async function getNextBranch(
 }
 
 
-function getTopBranch(
+async function getTopBranch(
     currentBranch: Branch,
     interactive: boolean,
-): string| undefined {
+): Promise<string| undefined> {
   let branch = currentBranch
   let candidates = branch.getChildrenFromMeta();
   let indent = 0
@@ -82,11 +82,34 @@ function getTopBranch(
       indent ++;
     } else {
       if (interactive) {
-        //TODO: deal with interactive option
+        return (
+            await prompts(
+                {
+                  type: "select",
+                  name: "branch",
+                  message: "Select a branch to checkout",
+                  choices: candidates.map((b) => {
+                    return { title: b.name, value: b.name };
+                  }),
+                },
+                {
+                  onCancel: () => {
+                    throw new KilledError();
+                  },
+                }
+            )
+        ).branch;
+      } else {
+        throw new ExitFailedError(
+            `Cannot get next branch, multiple choices available: [${candidates.join(
+                ", "
+            )}]`
+        );
       }
     }
     candidates = branch.getChildrenFromMeta();
   }
+
   logInfo(`${"  ".repeat(indent)}↳(${chalk.cyan(branch)})`);
   return branch?.name
 }
@@ -134,7 +157,7 @@ export async function topBranchAction(opts: {
   interactive: boolean;
 }): Promise<void> {
   const currentBranch = currentBranchPrecondition();
-  const topBranch = getTopBranch(currentBranch, opts.interactive);
+  const topBranch = await getTopBranch(currentBranch, opts.interactive);
   if (topBranch && topBranch !== currentBranch.name) {
     execSync(`git checkout "${topBranch}"`, { stdio: "ignore" });
     logInfo(`Switched to ${topBranch}`);

--- a/src/actions/stack_traversal.ts
+++ b/src/actions/stack_traversal.ts
@@ -28,8 +28,8 @@ function getBottomBranch(currentBranch: Branch): string | undefined {
 }
 
 async function getNextBranch(
-  currentBranch: Branch,
-  interactive: boolean
+    currentBranch: Branch,
+    interactive: boolean
 ): Promise<string | undefined> {
   const candidates = currentBranch.getChildrenFromMeta();
 
@@ -39,27 +39,27 @@ async function getNextBranch(
   if (candidates.length > 1) {
     if (interactive) {
       return (
-        await prompts(
-          {
-            type: "select",
-            name: "branch",
-            message: "Select a branch to checkout",
-            choices: candidates.map((b) => {
-              return { title: b.name, value: b.name };
-            }),
-          },
-          {
-            onCancel: () => {
-              throw new KilledError();
-            },
-          }
-        )
+          await prompts(
+              {
+                type: "select",
+                name: "branch",
+                message: "Select a branch to checkout",
+                choices: candidates.map((b) => {
+                  return { title: b.name, value: b.name };
+                }),
+              },
+              {
+                onCancel: () => {
+                  throw new KilledError();
+                },
+              }
+          )
       ).branch;
     } else {
       throw new ExitFailedError(
-        `Cannot get next branch, multiple choices available: [${candidates.join(
-          ", "
-        )}]`
+          `Cannot get next branch, multiple choices available: [${candidates.join(
+              ", "
+          )}]`
       );
     }
   } else {
@@ -75,6 +75,28 @@ async function getTopBranch(
   let branch = currentBranch
   let candidates = branch.getChildrenFromMeta();
   let indent = 0
+
+  async function get_stack_branch() : Promise<string>{
+    return (
+        await prompts(
+            {
+              type: "select",
+              name: "branch",
+              message: "Select a branch to checkout",
+              choices: candidates.map((b) => {
+                return {title: b.name, value: b.name, branch: b};
+              }),
+            },
+            {
+              onCancel: () => {
+                throw new KilledError();
+              },
+            }
+        )
+    ).branch;
+  }
+
+
   while (branch && candidates.length){
     if (candidates.length === 1) {
       logInfo(`${"  ".repeat(indent)}↳(${branch})`);
@@ -82,23 +104,8 @@ async function getTopBranch(
       indent ++;
     } else {
       if (interactive) {
-        return (
-            await prompts(
-                {
-                  type: "select",
-                  name: "branch",
-                  message: "Select a branch to checkout",
-                  choices: candidates.map((b) => {
-                    return { title: b.name, value: b.name };
-                  }),
-                },
-                {
-                  onCancel: () => {
-                    throw new KilledError();
-                  },
-                }
-            )
-        ).branch;
+        const stack_bottom_branch = await get_stack_branch();
+        branch = await Branch.branchWithName(stack_bottom_branch)
       } else {
         throw new ExitFailedError(
             `Cannot get next branch, multiple choices available: [${candidates.join(
@@ -123,18 +130,18 @@ export async function nextOrPrevAction(opts: {
   for (let i = 0; i < opts.numSteps; i++) {
     const currentBranch = currentBranchPrecondition();
     const branch =
-      opts.nextOrPrev === "next"
-        ? await getNextBranch(currentBranch, opts.interactive)
-        : getPrevBranch(currentBranch);
+        opts.nextOrPrev === "next"
+            ? await getNextBranch(currentBranch, opts.interactive)
+            : getPrevBranch(currentBranch);
 
     // Print indented branch names to show traversal.
     if (branch && branch !== currentBranch.name) {
       execSync(`git checkout "${branch}"`, { stdio: "ignore" });
       const indent = opts.nextOrPrev === "next" ? i : opts.numSteps - i - 1;
       logInfo(
-        `${"  ".repeat(indent)}↳(${
-          i === opts.numSteps - 1 ? chalk.cyan(branch) : branch
-        })`
+          `${"  ".repeat(indent)}↳(${
+              i === opts.numSteps - 1 ? chalk.cyan(branch) : branch
+          })`
       );
     } else {
       return;

--- a/src/actions/stack_traversal.ts
+++ b/src/actions/stack_traversal.ts
@@ -28,8 +28,8 @@ function getBottomBranch(currentBranch: Branch): string | undefined {
 }
 
 async function getNextBranch(
-    currentBranch: Branch,
-    interactive: boolean
+  currentBranch: Branch,
+  interactive: boolean
 ): Promise<string | undefined> {
   const candidates = currentBranch.getChildrenFromMeta();
 
@@ -39,27 +39,27 @@ async function getNextBranch(
   if (candidates.length > 1) {
     if (interactive) {
       return (
-          await prompts(
-              {
-                type: "select",
-                name: "branch",
-                message: "Select a branch to checkout",
-                choices: candidates.map((b) => {
-                  return { title: b.name, value: b.name };
-                }),
-              },
-              {
-                onCancel: () => {
-                  throw new KilledError();
-                },
-              }
-          )
+        await prompts(
+          {
+            type: "select",
+            name: "branch",
+            message: "Select a branch to checkout",
+            choices: candidates.map((b) => {
+              return { title: b.name, value: b.name };
+            }),
+          },
+          {
+            onCancel: () => {
+              throw new KilledError();
+            },
+          }
+        )
       ).branch;
     } else {
       throw new ExitFailedError(
-          `Cannot get next branch, multiple choices available: [${candidates.join(
-              ", "
-          )}]`
+        `Cannot get next branch, multiple choices available: [${candidates.join(
+            ", "
+        )}]`
       );
     }
   } else {
@@ -78,21 +78,21 @@ async function getTopBranch(
 
   async function get_stack_branch() : Promise<string>{
     return (
-        await prompts(
-            {
-              type: "select",
-              name: "branch",
-              message: "Select a branch to checkout",
-              choices: candidates.map((b) => {
-                return {title: b.name, value: b.name, branch: b};
-              }),
-            },
-            {
-              onCancel: () => {
-                throw new KilledError();
-              },
-            }
-        )
+      await prompts(
+        {
+          type: "select",
+          name: "branch",
+          message: "Select a branch to checkout",
+          choices: candidates.map((b) => {
+            return {title: b.name, value: b.name, branch: b};
+          }),
+        },
+        {
+          onCancel: () => {
+            throw new KilledError();
+          },
+        }
+      )
     ).branch;
   }
 
@@ -108,9 +108,9 @@ async function getTopBranch(
         branch = await Branch.branchWithName(stack_bottom_branch)
       } else {
         throw new ExitFailedError(
-            `Cannot get next branch, multiple choices available: [${candidates.join(
-                ", "
-            )}]`
+          `Cannot get next branch, multiple choices available: [${candidates.join(
+              ", "
+          )}]`
         );
       }
     }
@@ -130,18 +130,18 @@ export async function nextOrPrevAction(opts: {
   for (let i = 0; i < opts.numSteps; i++) {
     const currentBranch = currentBranchPrecondition();
     const branch =
-        opts.nextOrPrev === "next"
-            ? await getNextBranch(currentBranch, opts.interactive)
-            : getPrevBranch(currentBranch);
+      opts.nextOrPrev === "next"
+          ? await getNextBranch(currentBranch, opts.interactive)
+          : getPrevBranch(currentBranch);
 
     // Print indented branch names to show traversal.
     if (branch && branch !== currentBranch.name) {
       execSync(`git checkout "${branch}"`, { stdio: "ignore" });
       const indent = opts.nextOrPrev === "next" ? i : opts.numSteps - i - 1;
       logInfo(
-          `${"  ".repeat(indent)}↳(${
-              i === opts.numSteps - 1 ? chalk.cyan(branch) : branch
-          })`
+        `${"  ".repeat(indent)}↳(${
+            i === opts.numSteps - 1 ? chalk.cyan(branch) : branch
+        })`
       );
     } else {
       return;

--- a/src/actions/stack_traversal.ts
+++ b/src/actions/stack_traversal.ts
@@ -43,7 +43,7 @@ async function getNextBranch(
           {
             type: "select",
             name: "branch",
-            message: "Select a branch to checkout",
+            message: "Multiple branches found at the same level. Select a branch to guide the navigation to the top",
             choices: candidates.map((b) => {
               return { title: b.name, value: b.name };
             }),
@@ -57,7 +57,7 @@ async function getNextBranch(
       ).branch;
     } else {
       throw new ExitFailedError(
-        `Cannot get next branch, multiple choices available: [${candidates.join(
+        `Cannot determine top branch, multiple choices available: [${candidates.join(
           ", "
         )}]`
       );

--- a/src/actions/stack_traversal.ts
+++ b/src/actions/stack_traversal.ts
@@ -43,7 +43,7 @@ async function getNextBranch(
           {
             type: "select",
             name: "branch",
-            message: "Multiple branches found at the same level. Select a branch to guide the navigation to the top",
+            message: "Select a branch to checkout",
             choices: candidates.map((b) => {
               return { title: b.name, value: b.name };
             }),
@@ -57,7 +57,7 @@ async function getNextBranch(
       ).branch;
     } else {
       throw new ExitFailedError(
-        `Cannot determine top branch, multiple choices available: [${candidates.join(
+        `Cannot determine next branch, multiple choices available: [${candidates.join(
           ", "
         )}]`
       );
@@ -82,7 +82,7 @@ async function getTopBranch(
         {
           type: "select",
           name: "branch",
-          message: "Select a branch to checkout",
+          message: "Multiple branches found at the same level. Select a branch to guide the navigation to the top",
           choices: candidates.map((b) => {
             return {title: b.name, value: b.name, branch: b};
           }),
@@ -108,7 +108,7 @@ async function getTopBranch(
         branch = await Branch.branchWithName(stack_bottom_branch)
       } else {
         throw new ExitFailedError(
-          `Cannot get next branch, multiple choices available: [${candidates.join(
+          `Cannot determine the top branch, multiple choices available: [${candidates.join(
               ", "
           )}]`
         );

--- a/src/actions/stack_traversal.ts
+++ b/src/actions/stack_traversal.ts
@@ -58,7 +58,7 @@ async function getNextBranch(
     } else {
       throw new ExitFailedError(
         `Cannot get next branch, multiple choices available: [${candidates.join(
-            ", "
+          ", "
         )}]`
       );
     }
@@ -131,8 +131,8 @@ export async function nextOrPrevAction(opts: {
     const currentBranch = currentBranchPrecondition();
     const branch =
       opts.nextOrPrev === "next"
-          ? await getNextBranch(currentBranch, opts.interactive)
-          : getPrevBranch(currentBranch);
+        ? await getNextBranch(currentBranch, opts.interactive)
+        : getPrevBranch(currentBranch);
 
     // Print indented branch names to show traversal.
     if (branch && branch !== currentBranch.name) {
@@ -140,7 +140,7 @@ export async function nextOrPrevAction(opts: {
       const indent = opts.nextOrPrev === "next" ? i : opts.numSteps - i - 1;
       logInfo(
         `${"  ".repeat(indent)}↳(${
-            i === opts.numSteps - 1 ? chalk.cyan(branch) : branch
+          i === opts.numSteps - 1 ? chalk.cyan(branch) : branch
         })`
       );
     } else {

--- a/src/commands/branch-commands/top.ts
+++ b/src/commands/branch-commands/top.ts
@@ -1,0 +1,30 @@
+import yargs from "yargs";
+import { topBranchAction } from "../../actions/next_or_prev";
+// import { execStateConfig } from "../../lib/config";
+import { profile } from "../../lib/telemetry";
+import {execStateConfig} from "../../lib/config";
+
+const args = {
+    // steps: {
+    //     describe: `The number of levels to traverse downstack.`,
+    //     demandOption: false,
+    //     default: 1,
+    //     type: "number",
+    //     alias: "n",
+    // },
+} as const;
+
+type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
+
+export const command = "top";
+export const aliases = ["t"];
+export const description =
+    "If you're in a stack: Branch A → Branch B (you are here) → Branch C → Branch D , checkout the branch at the top of the stack (Branch D). If there are multiple parent branches in the stack, `gt top` will prompt you to choose which branch to checkout.";
+export const builder = args;
+export const handler = async (argv: argsT): Promise<void> => {
+    return profile(argv, async () => {
+        await topBranchAction({
+            interactive: execStateConfig.interactive(),
+        });
+    });
+};

--- a/src/commands/branch-commands/top.ts
+++ b/src/commands/branch-commands/top.ts
@@ -3,15 +3,7 @@ import { topBranchAction } from "../../actions/stack_traversal";
 import { profile } from "../../lib/telemetry";
 import {execStateConfig} from "../../lib/config";
 
-const args = {
-    // steps: {
-    //     describe: `The number of levels to traverse downstack.`,
-    //     demandOption: false,
-    //     default: 1,
-    //     type: "number",
-    //     alias: "n",
-    // },
-} as const;
+const args = {} as const;
 
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 

--- a/src/commands/branch-commands/top.ts
+++ b/src/commands/branch-commands/top.ts
@@ -1,5 +1,5 @@
 import yargs from "yargs";
-import { topBranchAction } from "../../actions/next_or_prev";
+import { topBranchAction } from "../../actions/stack_traversal";
 import { profile } from "../../lib/telemetry";
 import {execStateConfig} from "../../lib/config";
 

--- a/src/commands/branch-commands/top.ts
+++ b/src/commands/branch-commands/top.ts
@@ -18,7 +18,7 @@ type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 export const command = "top";
 export const aliases = ["t"];
 export const description =
-    "If you're in a stack: Branch A → Branch B (you are here) → Branch C → Branch D , checkout the branch at the top of the stack (Branch D). If there are multiple parent branches in the stack, `gt top` will prompt you to choose which branch to checkout.";
+    "If you're in a stack: Branch A → Branch B (you are here) → Branch C → Branch D , checkout the branch at the top of the stack (Branch D). If there are multiple parent branches in the stack, `gt branch top` will prompt you to choose which branch to checkout.";
 
 export const handler = async (argv: argsT): Promise<void> => {
     return profile(argv, async () => {

--- a/src/commands/branch-commands/top.ts
+++ b/src/commands/branch-commands/top.ts
@@ -1,6 +1,5 @@
 import yargs from "yargs";
 import { topBranchAction } from "../../actions/next_or_prev";
-// import { execStateConfig } from "../../lib/config";
 import { profile } from "../../lib/telemetry";
 import {execStateConfig} from "../../lib/config";
 
@@ -20,7 +19,7 @@ export const command = "top";
 export const aliases = ["t"];
 export const description =
     "If you're in a stack: Branch A → Branch B (you are here) → Branch C → Branch D , checkout the branch at the top of the stack (Branch D). If there are multiple parent branches in the stack, `gt top` will prompt you to choose which branch to checkout.";
-export const builder = args;
+
 export const handler = async (argv: argsT): Promise<void> => {
     return profile(argv, async () => {
         await topBranchAction({


### PR DESCRIPTION
**Context:**
Adding support for `gt branch top`

**Test Plan:**
Manual testing. Following commands should work:
`gt branch top` should take you the bottom-most, non-trunk branch on the stack. 

Interactive mode is supported since a branch can have multiple children. Upon selecting a child branch, the command will traverse to the top of the chosen stack.

