### PR TITLE
[Debug Context] Read from file, rather than plain string

### DIFF
--- a/src/commands/feedback-commands/debug_context.ts
+++ b/src/commands/feedback-commands/debug_context.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import fs from "fs-extra";
 import yargs from "yargs";
 import { captureState, recreateState } from "../../lib/debug-context";
 import { profile } from "../../lib/telemetry";
@@ -8,8 +9,16 @@ const args = {
   recreate: {
     type: "string",
     optional: true,
+    alias: "r",
     describe:
       "Accepts a json block created by `gt feedback state`. Recreates a debug repo in a temp folder with a commit tree matching the state JSON.",
+  },
+  "recreate-from-file": {
+    type: "string",
+    optional: true,
+    alias: "f",
+    describe:
+      "Accepts a file containing a json block created by `gt feedback state`. Recreates a debug repo in a temp folder with a commit tree matching the state JSON.",
   },
 } as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
@@ -21,7 +30,12 @@ export const builder = args;
 
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, async () => {
-    if (argv.recreate) {
+    if (argv["recreate-from-file"]) {
+      const dir = recreateState(
+        fs.readFileSync(argv["recreate-from-file"]).toString()
+      );
+      logInfo(`${chalk.green(dir)}`);
+    } else if (argv.recreate) {
       const dir = recreateState(argv.recreate);
       logInfo(`${chalk.green(dir)}`);
     } else {


### PR DESCRIPTION
**Changes In This Pull Request:**

Adds an option to read the debug context blob directly from a filepath.

**Test Plan:**

tested locally

