### PR TITLE
Export logDebug in lib/utils

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -3,6 +3,7 @@ import { getCommitterDate } from "./committer_date";
 import { detectStagedChanges } from "./detect_staged_changes";
 import { gpExecSync } from "./exec_sync";
 import GitRepo from "./git_repo";
+import { uncommittedChanges, unstagedChanges } from "./git_status_utils";
 import { makeId } from "./make_id";
 import { parseArgs } from "./parse_args";
 import { preprocessCommand } from "./preprocess_command";
@@ -10,6 +11,7 @@ import { rebaseInProgress } from "./rebase_in_progress";
 import { getRepoRootPath } from "./repo_root_path";
 import { signpostDeprecatedCommands } from "./signpost_deprecated_commands";
 import {
+  logDebug,
   logError,
   logInfo,
   logNewline,
@@ -18,12 +20,11 @@ import {
   logWarn,
 } from "./splog";
 import { getTrunk } from "./trunk";
-import { uncommittedChanges } from "./git_status_utils";
-import { unstagedChanges } from "./git_status_utils";
 import { VALIDATION_HELPER_MESSAGE } from "./validation_helper_message";
 
 export {
   gpExecSync,
+  logDebug,
   logError,
   logInfo,
   logSuccess,


### PR DESCRIPTION
Easy, as titled.

We export the rest of the methods in the file so doing for `logDebug` as well.