### PR TITLE
[Stack Builder] Merge stopgap

### DIFF
--- a/src/lib/utils/git_repo.ts
+++ b/src/lib/utils/git_repo.ts
@@ -1,7 +1,6 @@
 import { execSync } from "child_process";
 import fs from "fs-extra";
-import { rebaseInProgress } from "./";
-import { unstagedChanges } from "./";
+import { rebaseInProgress, unstagedChanges } from "./";
 
 const TEXT_FILE_NAME = "test.txt";
 export default class GitRepo {
@@ -105,5 +104,14 @@ export default class GitRepo {
       .trim()
       .split("\n")
       .filter((line) => line.length > 0);
+  }
+
+  mergeBranch(args: { branch: string; mergeIn: string }): void {
+    execSync(
+      `git -C "${this.dir}" checkout ${args.branch}; git merge ${args.mergeIn}`,
+      {
+        stdio: "ignore",
+      }
+    );
   }
 }


### PR DESCRIPTION
**Context:**


**Changes In This Pull Request:**

This follows the same strategy as the previous PR (#354), but adds the logic to our abstract stack builder.

Note that we need to add this in 2 places since our log logic doesn't use our abstract stack building logic yet; that's a task that I'll take on at a later date.

This change is a lot more ugly since we need to worry more about correctness here and make sure that we deterministically determine which branches to short-circuit. This tech debt highlights to me that we need a proper fix to merges sooner rather than later.

**Test Plan:**

existing tests still pass, added a new test