### PR TITLE
[Log] Stopgap to handle merges

### DIFF
--- a/src/commands/branch-commands/sync.ts
+++ b/src/commands/branch-commands/sync.ts
@@ -46,6 +46,7 @@ export const handler = async (argv: argsT): Promise<void> => {
       getBranchTitle(branch, {
         currentBranch: null,
         offTrunk: false,
+        visited: [],
       })
     );
 

--- a/src/commands/log-commands/default.ts
+++ b/src/commands/log-commands/default.ts
@@ -50,6 +50,7 @@ function printTrunkLog(): void {
     config: {
       currentBranch: Branch.getCurrentBranch(),
       offTrunk: true,
+      visited: [],
     },
   });
 }
@@ -82,6 +83,7 @@ async function printStacksBehindTrunk(): Promise<void> {
       config: {
         currentBranch: Branch.getCurrentBranch(),
         offTrunk: false,
+        visited: [],
       },
     });
     console.log(`◌──┘`);


### PR DESCRIPTION
**Context:**

Today, log doesn't handle merges well.

Consider the following case:
* we have branch A, off of which exist branches B and C
* we merge branch B back into C

We get this triangle case:
```
C
|\
| B
|/
A
```

Right now, we print out the log by doing a DFS which in the above case prints C twice: once when we process the subtree of A and another time when we process the subtree of B.

**Changes In This Pull Request:**

This PR adds a temporary stop-gap in the `printStack` method to keep track of visited nodes and skip those.

Note that a larger holistic fix is needed for the CLI, but this should do for the near term.

**Test Plan:**

pre-existing tests pass; Tomas's log no longer infinitely prints

