### PR TITLE
[Repo Sync] Eagerly delete branches during repo sync

### DIFF
--- a/src/lib/debug-context/index.ts
+++ b/src/lib/debug-context/index.ts
@@ -14,6 +14,7 @@ type stateT = {
   userConfig: string;
   repoConfig: string;
   metadata: Record<string, string>;
+  currentBranchName: string;
 };
 export function captureState(): string {
   const refTree = getRevListGitTree({
@@ -27,12 +28,15 @@ export function captureState(): string {
     metadata[ref._branchName] = JSON.stringify(ref.read());
   });
 
+  const currentBranchName = currentBranchPrecondition().name;
+
   const state: stateT = {
     refTree,
     branchToRefMapping,
     userConfig: JSON.stringify(userConfig._data),
     repoConfig: JSON.stringify(repoConfig._data),
     metadata,
+    currentBranchName,
   };
 
   return JSON.stringify(state, null, 2);
@@ -66,7 +70,7 @@ export function recreateState(stateJson: string): string {
   logInfo(`Creating the metadata`);
   createMetadata({ metadata: state.metadata, tmpDir });
 
-  gpExecSync({ command: `git checkout "${repoConfig.getTrunk()}"` });
+  gpExecSync({ command: `git checkout "${state.currentBranchName}"` });
   gpExecSync({ command: `git branch -D "${tmpTrunk}"` });
 
   return tmpDir;


### PR DESCRIPTION
**Context:**

Right now, in `repo sync`, we delete branches in a 3-step process:
* run through and find all of the branches we want to delete
* then go and upstack all of their children
* finally, go through and actually delete all the branches that can now be deleted

This is usually fine but is frustrating if you have lots and lots of stale branches -- you don't get any feedback from the command and if you kill it before step 3, you lose all of the work it just did. (Was running it on a repo with 300 stale branches today and it was taking on the order of > 5 minutes so it'd be easy to just kill it, thinking it was hanging.)

Since we want to encourage users to cull these large sets of stale branches, we should strive to make this as easy as possible.

**Changes In This Pull Request:**

This PR changes our strategy to delete stale branches eagerly, as soon as we know that we can.

With the new logic:
* do a DFS and keep track of the branches we want to delete as well as their children that need to be upstacked
* when a branch to-be-deleted has no more active children, just delete it

The logic is more complex, but the payoff is that branches are deleted significantly faster in these large cases now. As `repo sync` chugs along, you can see branches being deleted right as its doing work.

**Test Plan:**

existing functionality tests over the whole of `repo sync` still pass; noticed the significant speedup with Jonas's debug context

