### PR TITLE
[Repo Fix] New commmand

### DIFF
--- a/src/actions/clean_branches.ts
+++ b/src/actions/clean_branches.ts
@@ -1,0 +1,226 @@
+import chalk from "chalk";
+import { execSync } from "child_process";
+import prompts from "prompts";
+import { cache } from "../lib/config";
+import { KilledError } from "../lib/errors";
+import { checkoutBranch, getTrunk, logInfo } from "../lib/utils";
+import Branch from "../wrapper-classes/branch";
+import { ontoAction } from "./onto";
+
+// eslint-disable-next-line max-lines-per-function
+export async function deleteMergedBranches(opts: {
+  force: boolean;
+  showDeleteProgress: boolean;
+}): Promise<void> {
+  const trunkChildren = getTrunk().getChildrenFromMeta();
+
+  /**
+   * To find and delete all of the merged branches, we traverse all of the
+   * stacks off of trunk, greedily deleting the merged-in base branches and
+   * rebasing the remaining branches.
+   *
+   * To greedily delete the branches, we keep track of the branches we plan
+   * to delete as well as a live snapshot of their children. When a branch
+   * we plan to delete has no more children, we know that it is safe to
+   * eagerly delete.
+   *
+   * This eager deletion doesn't matter much in small repos, but matters
+   * a lot if a repo has a lot of branches to delete. Whereas previously
+   * any error in `repo sync` would throw away all of the work the command did
+   * to determine what could and couldn't be deleted, now we take advantage
+   * of that work as soon as we can.
+   */
+  let toProcess: Branch[] = trunkChildren;
+  const branchesToDelete: Record<
+    string,
+    {
+      branch: Branch;
+      children: Branch[];
+    }
+  > = {};
+
+  /**
+   * Since we're doing a DFS, assuming rather even distribution of stacks off
+   * of trunk children, we can trace the progress of the DFS through the trunk
+   * children to give the user a sense of how far the repo sync has progressed.
+   * Note that we only do this if the user has a large number of branches off
+   * of trunk (> 50).
+   */
+  const trunkChildrenProgressMarkers: Record<string, string> = {};
+  if (opts.showDeleteProgress) {
+    trunkChildren.forEach((child, i) => {
+      // Ignore the first child - don't show 0% progress.
+      if (i === 0) {
+        return;
+      }
+
+      trunkChildrenProgressMarkers[child.name] = `${+(
+        // Add 1 to the overall children length to account for the fact that
+        // when we're on the last trunk child, we're not 100% done - we need
+        // to go through its stack.
+        ((i / (trunkChildren.length + 1)) * 100).toFixed(2)
+      )}%`;
+    });
+  }
+
+  do {
+    const branch = toProcess.shift();
+    if (branch === undefined) {
+      break;
+    }
+
+    if (branch.name in branchesToDelete) {
+      continue;
+    }
+
+    if (
+      opts.showDeleteProgress &&
+      branch.name in trunkChildrenProgressMarkers
+    ) {
+      logInfo(
+        `${
+          trunkChildrenProgressMarkers[branch.name]
+        } done searching for merged branches to delete...`
+      );
+    }
+
+    const shouldDelete = await shouldDeleteBranch({
+      branch: branch,
+      force: opts.force,
+    });
+    if (shouldDelete) {
+      const children = branch.getChildrenFromMeta();
+
+      // We concat toProcess to children here (because we shift above) to make
+      // our search a DFS.
+      toProcess = children.concat(toProcess);
+
+      branchesToDelete[branch.name] = {
+        branch: branch,
+        children: children,
+      };
+    } else {
+      const parent = branch.getParentFromMeta();
+      const parentName = parent?.name;
+
+      // If we've reached this point, we know the branch shouldn't be deleted.
+      // This means that we may need to rebase it - if the branch's parent is
+      // going to be deleted.
+      if (parentName !== undefined && parentName in branchesToDelete) {
+        checkoutBranch(branch.name);
+        logInfo(`upstacking (${branch.name}) onto (${getTrunk().name})`);
+        await ontoAction(getTrunk().name);
+
+        branchesToDelete[parentName].children = branchesToDelete[
+          parentName
+        ].children.filter((child) => child.name !== branch.name);
+      }
+    }
+
+    checkoutBranch(getTrunk().name);
+
+    // With either of the paths above, we may have unblocked a branch that can
+    // be deleted immediately. We recursively check whether we can delete a
+    // branch (until we can't), because the act of deleting one branch may free
+    // up another.
+    let branchToDeleteName;
+    do {
+      branchToDeleteName = Object.keys(branchesToDelete).find(
+        (branchToDelete) =>
+          branchesToDelete[branchToDelete].children.length === 0
+      );
+      if (branchToDeleteName === undefined) {
+        continue;
+      }
+
+      const branch = branchesToDelete[branchToDeleteName].branch;
+      const parentName = branch.getParentFromMeta()?.name;
+      if (parentName !== undefined && parentName in branchesToDelete) {
+        branchesToDelete[parentName].children = branchesToDelete[
+          parentName
+        ].children.filter((child) => child.name !== branch.name);
+      }
+
+      await deleteBranch(branch);
+      delete branchesToDelete[branchToDeleteName];
+    } while (branchToDeleteName !== undefined);
+  } while (toProcess.length > 0);
+}
+
+async function shouldDeleteBranch(args: {
+  branch: Branch;
+  force: boolean;
+}): Promise<boolean> {
+  const merged = branchMerged(args.branch);
+  if (!merged) {
+    return false;
+  }
+
+  if (args.force) {
+    return true;
+  }
+
+  const githubMergedBase =
+    args.branch.getPRInfo()?.state === "MERGED"
+      ? args.branch.getPRInfo()?.base
+      : undefined;
+
+  // If we've reached this point, we know that the branch was merged - it's
+  // just a question of where. If it was merged on GitHub, we see where it was
+  // merged into. If we don't detect that it was merged in GitHub but we do
+  // see the code in trunk, we fallback to say that it was merged into trunk.
+  // This extra check (rather than just saying trunk) is used to catch the
+  // case where one feature branch is merged into another on GitHub.
+  const mergedBase = githubMergedBase ?? getTrunk().name;
+
+  const response = await prompts(
+    {
+      type: "confirm",
+      name: "value",
+      message: `Delete (${chalk.green(
+        args.branch.name
+      )}), which has been merged into (${mergedBase})?`,
+      initial: true,
+    },
+    {
+      onCancel: () => {
+        throw new KilledError();
+      },
+    }
+  );
+  return response.value === true;
+}
+
+function branchMerged(branch: Branch): boolean {
+  const prMerged = branch.getPRInfo()?.state === "MERGED";
+  if (prMerged) {
+    return true;
+  }
+
+  const branchName = branch.name;
+  const trunk = getTrunk().name;
+  const cherryCheckProvesMerged = execSync(
+    `mergeBase=$(git merge-base ${trunk} ${branchName}) && git cherry ${trunk} $(git commit-tree $(git rev-parse "${branchName}^{tree}") -p $mergeBase -m _)`
+  )
+    .toString()
+    .trim()
+    .startsWith("-");
+  if (cherryCheckProvesMerged) {
+    return true;
+  }
+
+  const diffCheckProvesMerged =
+    execSync(`git diff ${branchName} ${trunk} | wc -l`).toString().trim() ===
+    "0";
+  if (diffCheckProvesMerged) {
+    return true;
+  }
+
+  return false;
+}
+
+async function deleteBranch(branch: Branch) {
+  logInfo(`Deleting (${chalk.red(branch.name)})`);
+  execSync(`git branch -D ${branch.name}`);
+  cache.clearAll();
+}

--- a/src/actions/fix_dangling_branches.ts
+++ b/src/actions/fix_dangling_branches.ts
@@ -1,0 +1,88 @@
+import chalk from "chalk";
+import prompts from "prompts";
+import { repoConfig } from "../lib/config";
+import { KilledError } from "../lib/errors";
+import { getTrunk, logInfo } from "../lib/utils";
+import Branch from "../wrapper-classes/branch";
+
+export function existsDanglingBranches(): boolean {
+  const danglingBranches = Branch.allBranchesWithFilter({
+    filter: (b) => !b.isTrunk() && b.getParentFromMeta() === undefined,
+  });
+  return danglingBranches.length > 0;
+}
+
+export async function fixDanglingBranches(force: boolean): Promise<void> {
+  const danglingBranches = Branch.allBranchesWithFilter({
+    filter: (b) => !b.isTrunk() && b.getParentFromMeta() === undefined,
+  });
+
+  const trunk = getTrunk().name;
+  for (const branch of danglingBranches) {
+    type TFixStrategy = "parent_trunk" | "ignore_branch" | "no_fix" | undefined;
+    let fixStrategy: TFixStrategy | undefined = undefined;
+
+    if (force) {
+      fixStrategy = "parent_trunk";
+      logInfo(`Setting parent of ${branch.name} to ${trunk}.`);
+    }
+
+    if (fixStrategy === undefined) {
+      const response = await prompts(
+        {
+          type: "select",
+          name: "value",
+          message: `${branch.name}`,
+          choices: [
+            {
+              title: `Set ${chalk.green(
+                `(${branch.name})`
+              )}'s parent to ${trunk}`,
+              value: "parent_trunk",
+            },
+            {
+              title: `Add ${chalk.green(
+                `(${branch.name})`
+              )} to the list of branches Graphite should ignore`,
+              value: "ignore_branch",
+            },
+            { title: `Fix later`, value: "no_fix" },
+          ],
+        },
+        {
+          onCancel: () => {
+            throw new KilledError();
+          },
+        }
+      );
+
+      switch (response.value) {
+        case "parent_trunk":
+          fixStrategy = "parent_trunk";
+          break;
+        case "ignore_branch":
+          fixStrategy = "ignore_branch";
+          break;
+        case "no_fix":
+        default:
+          fixStrategy = "no_fix";
+      }
+    }
+
+    switch (fixStrategy) {
+      case "parent_trunk":
+        branch.setParentBranchName(trunk);
+        break;
+      case "ignore_branch":
+        repoConfig.addIgnoredBranches([branch.name]);
+        break;
+      case "no_fix":
+        break;
+      default:
+        assertUnreachable(fixStrategy);
+    }
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function assertUnreachable(arg: never): void {}

--- a/src/actions/sync.ts
+++ b/src/actions/sync.ts
@@ -1,12 +1,6 @@
-import chalk from "chalk";
-import { execSync } from "child_process";
 import prompts from "prompts";
-import { cache, repoConfig } from "../lib/config";
-import {
-  ExitFailedError,
-  KilledError,
-  PreconditionsFailedError,
-} from "../lib/errors";
+import { repoConfig } from "../lib/config";
+import { ExitFailedError, PreconditionsFailedError } from "../lib/errors";
 import {
   cliAuthPrecondition,
   currentBranchPrecondition,
@@ -22,7 +16,8 @@ import {
 import { logDebug, logNewline, logTip } from "../lib/utils/splog";
 import Branch from "../wrapper-classes/branch";
 import MetadataRef from "../wrapper-classes/metadata_ref";
-import { ontoAction } from "./onto";
+import { deleteMergedBranches } from "./clean_branches";
+import { fixDanglingBranches } from "./fix_dangling_branches";
 import { submitBranches } from "./submit";
 
 export async function syncAction(opts: {
@@ -55,10 +50,18 @@ export async function syncAction(opts: {
   // This needs to happen before we delete/resubmit so that we can potentially
   // delete or resubmit on the dangling branches.
   if (opts.fixDanglingBranches) {
+    logNewline();
+    logInfo(`Ensuring tracked branches in Graphite are all well-formed...`);
+    logTip(
+      `Disable this behavior at any point in the future with --no-show-dangling`
+    );
     await fixDanglingBranches(opts.force);
   }
 
   if (opts.delete) {
+    logNewline();
+    logInfo(`Checking if any branches have been merged and can be deleted...`);
+    logTip(`Disable this behavior at any point in the future with --no-delete`);
     await deleteMergedBranches({
       force: opts.force,
       showDeleteProgress: opts.showDeleteProgress,
@@ -72,316 +75,6 @@ export async function syncAction(opts: {
   checkoutBranch(Branch.exists(oldBranch.name) ? oldBranch.name : trunk);
   cleanDanglingMetadata();
 }
-
-// eslint-disable-next-line max-lines-per-function
-async function deleteMergedBranches(opts: {
-  force: boolean;
-  showDeleteProgress: boolean;
-}): Promise<void> {
-  logNewline();
-  logInfo(`Checking if any branches have been merged and can be deleted...`);
-  logTip(`Disable this behavior at any point in the future with --no-delete`);
-
-  const trunkChildren = getTrunk().getChildrenFromMeta();
-
-  /**
-   * To find and delete all of the merged branches, we traverse all of the
-   * stacks off of trunk, greedily deleting the merged-in base branches and
-   * rebasing the remaining branches.
-   *
-   * To greedily delete the branches, we keep track of the branches we plan
-   * to delete as well as a live snapshot of their children. When a branch
-   * we plan to delete has no more children, we know that it is safe to
-   * eagerly delete.
-   *
-   * This eager deletion doesn't matter much in small repos, but matters
-   * a lot if a repo has a lot of branches to delete. Whereas previously
-   * any error in `repo sync` would throw away all of the work the command did
-   * to determine what could and couldn't be deleted, now we take advantage
-   * of that work as soon as we can.
-   */
-  let toProcess: Branch[] = trunkChildren;
-  const branchesToDelete: Record<
-    string,
-    {
-      branch: Branch;
-      children: Branch[];
-    }
-  > = {};
-
-  /**
-   * Since we're doing a DFS, assuming rather even distribution of stacks off
-   * of trunk children, we can trace the progress of the DFS through the trunk
-   * children to give the user a sense of how far the repo sync has progressed.
-   * Note that we only do this if the user has a large number of branches off
-   * of trunk (> 50).
-   */
-  const trunkChildrenProgressMarkers: Record<string, string> = {};
-  if (opts.showDeleteProgress) {
-    trunkChildren.forEach((child, i) => {
-      // Ignore the first child - don't show 0% progress.
-      if (i === 0) {
-        return;
-      }
-
-      trunkChildrenProgressMarkers[child.name] = `${+(
-        // Add 1 to the overall children length to account for the fact that
-        // when we're on the last trunk child, we're not 100% done - we need
-        // to go through its stack.
-        ((i / (trunkChildren.length + 1)) * 100).toFixed(2)
-      )}%`;
-    });
-  }
-
-  do {
-    const branch = toProcess.shift();
-    if (branch === undefined) {
-      break;
-    }
-
-    if (branch.name in branchesToDelete) {
-      continue;
-    }
-
-    if (
-      opts.showDeleteProgress &&
-      branch.name in trunkChildrenProgressMarkers
-    ) {
-      logInfo(
-        `${
-          trunkChildrenProgressMarkers[branch.name]
-        } done searching for merged branches to delete...`
-      );
-    }
-
-    const shouldDelete = await shouldDeleteBranch({
-      branch: branch,
-      force: opts.force,
-    });
-    if (shouldDelete) {
-      const children = branch.getChildrenFromMeta();
-
-      // We concat toProcess to children here (because we shift above) to make
-      // our search a DFS.
-      toProcess = children.concat(toProcess);
-
-      branchesToDelete[branch.name] = {
-        branch: branch,
-        children: children,
-      };
-    } else {
-      const parent = branch.getParentFromMeta();
-      const parentName = parent?.name;
-
-      // If we've reached this point, we know the branch shouldn't be deleted.
-      // This means that we may need to rebase it - if the branch's parent is
-      // going to be deleted.
-      if (parentName !== undefined && parentName in branchesToDelete) {
-        checkoutBranch(branch.name);
-        logInfo(`upstacking (${branch.name}) onto (${getTrunk().name})`);
-        await ontoAction(getTrunk().name);
-
-        branchesToDelete[parentName].children = branchesToDelete[
-          parentName
-        ].children.filter((child) => child.name !== branch.name);
-      }
-    }
-
-    checkoutBranch(getTrunk().name);
-
-    // With either of the paths above, we may have unblocked a branch that can
-    // be deleted immediately. We recursively check whether we can delete a
-    // branch (until we can't), because the act of deleting one branch may free
-    // up another.
-    let branchToDeleteName;
-    do {
-      branchToDeleteName = Object.keys(branchesToDelete).find(
-        (branchToDelete) =>
-          branchesToDelete[branchToDelete].children.length === 0
-      );
-      if (branchToDeleteName === undefined) {
-        continue;
-      }
-
-      const branch = branchesToDelete[branchToDeleteName].branch;
-      const parentName = branch.getParentFromMeta()?.name;
-      if (parentName !== undefined && parentName in branchesToDelete) {
-        branchesToDelete[parentName].children = branchesToDelete[
-          parentName
-        ].children.filter((child) => child.name !== branch.name);
-      }
-
-      await deleteBranch(branch);
-      delete branchesToDelete[branchToDeleteName];
-    } while (branchToDeleteName !== undefined);
-  } while (toProcess.length > 0);
-}
-
-async function shouldDeleteBranch(args: {
-  branch: Branch;
-  force: boolean;
-}): Promise<boolean> {
-  const merged = branchMerged(args.branch);
-  if (!merged) {
-    return false;
-  }
-
-  if (args.force) {
-    return true;
-  }
-
-  const githubMergedBase =
-    args.branch.getPRInfo()?.state === "MERGED"
-      ? args.branch.getPRInfo()?.base
-      : undefined;
-
-  // If we've reached this point, we know that the branch was merged - it's
-  // just a question of where. If it was merged on GitHub, we see where it was
-  // merged into. If we don't detect that it was merged in GitHub but we do
-  // see the code in trunk, we fallback to say that it was merged into trunk.
-  // This extra check (rather than just saying trunk) is used to catch the
-  // case where one feature branch is merged into another on GitHub.
-  const mergedBase = githubMergedBase ?? getTrunk().name;
-
-  const response = await prompts(
-    {
-      type: "confirm",
-      name: "value",
-      message: `Delete (${chalk.green(
-        args.branch.name
-      )}), which has been merged into (${mergedBase})?`,
-      initial: true,
-    },
-    {
-      onCancel: () => {
-        throw new KilledError();
-      },
-    }
-  );
-  return response.value === true;
-}
-
-function branchMerged(branch: Branch): boolean {
-  const prMerged = branch.getPRInfo()?.state === "MERGED";
-  if (prMerged) {
-    return true;
-  }
-
-  const branchName = branch.name;
-  const trunk = getTrunk().name;
-  const cherryCheckProvesMerged = execSync(
-    `mergeBase=$(git merge-base ${trunk} ${branchName}) && git cherry ${trunk} $(git commit-tree $(git rev-parse "${branchName}^{tree}") -p $mergeBase -m _)`
-  )
-    .toString()
-    .trim()
-    .startsWith("-");
-  if (cherryCheckProvesMerged) {
-    return true;
-  }
-
-  const diffCheckProvesMerged =
-    execSync(`git diff ${branchName} ${trunk} | wc -l`).toString().trim() ===
-    "0";
-  if (diffCheckProvesMerged) {
-    return true;
-  }
-
-  return false;
-}
-
-async function deleteBranch(branch: Branch) {
-  logInfo(`Deleting (${chalk.red(branch.name)})`);
-  execSync(`git branch -D ${branch.name}`);
-  cache.clearAll();
-}
-
-async function fixDanglingBranches(force: boolean): Promise<void> {
-  const danglingBranches = Branch.allBranchesWithFilter({
-    filter: (b) => !b.isTrunk() && b.getParentFromMeta() === undefined,
-  });
-  if (danglingBranches.length === 0) {
-    return;
-  }
-
-  logNewline();
-  console.log(
-    chalk.yellow(
-      `Detected branches in Graphite without a known parent. Suggesting a fix...`
-    )
-  );
-  logTip(
-    `Disable this behavior at any point in the future with --no-show-dangling`
-  );
-
-  const trunk = getTrunk().name;
-  for (const branch of danglingBranches) {
-    type TFixStrategy = "parent_trunk" | "ignore_branch" | "no_fix" | undefined;
-    let fixStrategy: TFixStrategy | undefined = undefined;
-
-    if (force) {
-      fixStrategy = "parent_trunk";
-      logInfo(`Setting parent of ${branch.name} to ${trunk}.`);
-    }
-
-    if (fixStrategy === undefined) {
-      const response = await prompts(
-        {
-          type: "select",
-          name: "value",
-          message: `${branch.name}`,
-          choices: [
-            {
-              title: `Set ${chalk.green(
-                `(${branch.name})`
-              )}'s parent to ${trunk}`,
-              value: "parent_trunk",
-            },
-            {
-              title: `Add ${chalk.green(
-                `(${branch.name})`
-              )} to the list of branches Graphite should ignore`,
-              value: "ignore_branch",
-            },
-            { title: `Fix later`, value: "no_fix" },
-          ],
-        },
-        {
-          onCancel: () => {
-            throw new KilledError();
-          },
-        }
-      );
-
-      switch (response.value) {
-        case "parent_trunk":
-          fixStrategy = "parent_trunk";
-          break;
-        case "ignore_branch":
-          fixStrategy = "ignore_branch";
-          break;
-        case "no_fix":
-        default:
-          fixStrategy = "no_fix";
-      }
-    }
-
-    switch (fixStrategy) {
-      case "parent_trunk":
-        branch.setParentBranchName(trunk);
-        break;
-      case "ignore_branch":
-        repoConfig.addIgnoredBranches([branch.name]);
-        break;
-      case "no_fix":
-        break;
-      default:
-        assertUnreachable(fixStrategy);
-    }
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-function assertUnreachable(arg: never): void {}
 
 function cleanDanglingMetadata(): void {
   const allMetadataRefs = MetadataRef.allMetadataRefs();

--- a/src/commands/repo-commands/fix.ts
+++ b/src/commands/repo-commands/fix.ts
@@ -1,0 +1,93 @@
+import chalk from "chalk";
+import yargs from "yargs";
+import { deleteMergedBranches } from "../../actions/clean_branches";
+import {
+  existsDanglingBranches,
+  fixDanglingBranches,
+} from "../../actions/fix_dangling_branches";
+import { profile } from "../../lib/telemetry";
+import { logInfo, logNewline, logTip } from "../../lib/utils";
+import Branch from "../../wrapper-classes/branch";
+
+const args = {
+  force: {
+    describe: `Don't prompt you to confirm whether to take a remediation (may include deleting already-merged branches and setting branch parents).`,
+    demandOption: false,
+    default: false,
+    type: "boolean",
+    alias: "f",
+  },
+  "show-delete-progress": {
+    describe: `Show progress through merged branches.`,
+    demandOption: false,
+    default: false,
+    type: "boolean",
+  },
+} as const;
+
+type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
+
+export const command = "fix";
+export const description =
+  "Search for and remediate common problems in your repo that slow Graphite down and/or cause bugs (e.g. stale branches, branches with unknown parents).";
+export const builder = args;
+export const handler = async (argv: argsT): Promise<void> => {
+  return profile(argv, async () => {
+    await branchMetadataSanityChecks(argv.force);
+    await branchCountSanityCheck({
+      force: argv.force,
+      showDeleteProgress: argv["show-delete-progress"],
+    });
+  });
+};
+
+async function branchMetadataSanityChecks(force: boolean): Promise<void> {
+  logInfo(`Ensuring tracked branches in Graphite are all well-formed...`);
+  if (existsDanglingBranches()) {
+    logNewline();
+    console.log(
+      chalk.yellow(
+        `Found branches without a known parent to Graphite. This may cause issues detecting stacks; we recommend you select one of the proposed remediations or use \`gt upstack onto\` to restack the branch onto the appropriate parent.`
+      )
+    );
+    logTip(
+      `To ensure Graphite always has a known parent for your branch, create your branch through Graphite with \`gt branch create <branch_name>\`.`
+    );
+    logNewline();
+    await fixDanglingBranches(force);
+    logNewline();
+  } else {
+    logInfo(`All branches well-formed.`);
+    logNewline();
+  }
+}
+
+async function branchCountSanityCheck(opts: {
+  force: boolean;
+  showDeleteProgress: boolean;
+}): Promise<void> {
+  const branchCount = Branch.allBranches().length;
+  if (branchCount > 50) {
+    console.log(
+      chalk.yellow(
+        `Found ${branchCount} total branches in the local repo which may be causing performance issues with Graphite. We recommend culling as many unneeded branches as possible to optimize Graphite performance.`
+      )
+    );
+    logTip(
+      `To further reduce Graphite's search space, you can also tune the maximum days and/or stacks Graphite tracks behind trunk using \`gt repo max-days-behind-trunk --set\` or \`gt repo max-stacks-behind-trunk --set\`.`
+    );
+    logNewline();
+  }
+
+  logInfo(`Searching for any stale branches that can be removed...`);
+
+  await deleteMergedBranches({
+    showDeleteProgress: opts.showDeleteProgress,
+    force: opts.force,
+  });
+
+  logNewline();
+  logInfo(
+    `Still seeing issues with Graphite? Send us feedback via \`gt feedback '<your_issue'> --with-debug-context\` and we'll dig in!`
+  );
+}


### PR DESCRIPTION
**Context:**

With the prior PRs, we now have a good way to aid users in removing stale branches — even in large cases.

The payoff is a new fix command which we can provide users when they're running into performance issues.

**Changes In This Pull Request:**

This PR introduces said command, breaking out the logic in `repo sync` into shared code.

The fix command for now:
* checks if there are dangling branches (and guides the user with fixing them)
* asks the user if they'd like to remove their stale branches, one-by-one

**Test Plan:**

yarn build; ran fix in Jonas's debug context

