### PR TITLE
[Repo Sync] Add option to show deletion progress

### DIFF
--- a/src/commands/repo-commands/repo_sync.ts
+++ b/src/commands/repo-commands/repo_sync.ts
@@ -10,6 +10,12 @@ const args = {
     type: "boolean",
     alias: "d",
   },
+  "show-delete-progress": {
+    describe: `Show progress through merged branches.`,
+    demandOption: false,
+    default: false,
+    type: "boolean",
+  },
   resubmit: {
     describe: `Re-submit branches whose merge bases have changed locally and now differ from their PRs.`,
     demandOption: false,
@@ -53,6 +59,7 @@ export const handler = async (argv: argsT): Promise<void> => {
       force: argv.force,
       resubmit: argv.resubmit,
       delete: argv.delete,
+      showDeleteProgress: argv["show-delete-progress"],
       fixDanglingBranches: argv["show-dangling"],
     });
   });


### PR DESCRIPTION
**Context:**

In the 300 stale branch case, it's still agonizing to see it chug along without any idea of how long the overall command will take.

**Changes In This Pull Request:**

This PR adds a progress indicator. The progress indicator isn't perfect, especially since we don't want to go through every branch and determine whether it was merged -- that'd be far to slow. Instead, we estimate that the user's stacks are fairly evenly distributed and calculate progress based on the stack base index that we've reached in the DFS.

Since this is far from perfect, this flag is opt-in. The idea is that we just tell folks to turn it on if they're doing a `repo sync` that is deleting a particularly high number of stale branches. 

**Test Plan:**

tested locally

![image](https://user-images.githubusercontent.com/9063972/135359551-52abee0d-4ce6-4a71-990e-b46505bd46e7.png)

