### PR TITLE
[Repo Init] Handle empty repo properly

### DIFF
--- a/src/lib/telemetry/profile.ts
+++ b/src/lib/telemetry/profile.ts
@@ -35,10 +35,8 @@ export async function profile(
   const parsedArgs = parseArgs(args);
   const start = Date.now();
   registerSigintHandler({ commandName: parsedArgs.command, startTime: start });
+
   if (parsedArgs.command !== "repo init" && !repoConfig.getTrunk()) {
-    logInfo(
-      `No trunk branch specified in "${repoConfig.path()}", please choose now.`
-    );
     await init();
   }
 

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -249,7 +249,10 @@ export default class Branch {
       .toString()
       .trim()
       .split("\n")
-      .filter((name) => !repoConfig.getIgnoreBranches().includes(name))
+      .filter(
+        (name) =>
+          !repoConfig.getIgnoreBranches().includes(name) && name.length > 0
+      )
       .map((name) => new Branch(name));
   }
 


### PR DESCRIPTION
**Context:**

Right now, when users run Graphite in an empty repo, they receive a cryptic message to set their trunk to `[object Object]`. Digging in, this is the result of multiple bugs:

1. When a branch new repo is initialized, it has no branches: https://newbedev.com/git-branch-not-returning-any-results. We could try to dig in harder to figure what the orphan branch is, but Googling around there's no trivial way to do this, and I worry about this causing further breakages as we're going against the grain here. Even git gives an error when you try to find a branch in an empty repo:

```
~/test  git init                                                                               ✔
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint: 	git branch -m <name>
Initialized empty Git repository in /Users/macmini/test/.git/
 ~/test  master  git checkout master                                                           ✔
error: pathspec 'master' did not match any file(s) known to git
```

2. When there are no branches, allBranches returns an empty string — we don't filter out empty-string-named branches in that method.

**Changes In This Pull Request:**

This diff fixes #2 and throws an error when we discover we're in the scenario described by #1.

**Test Plan:**

![image](https://user-images.githubusercontent.com/9063972/135511005-2c639c50-ada3-4e8e-9e06-6dcbf172d53c.png)


