### PR TITLE
Fix welcome message

### DIFF
--- a/src/actions/init.ts
+++ b/src/actions/init.ts
@@ -75,10 +75,10 @@ export async function init(
 }
 
 function logWelcomeMessage(): void {
-  if (!fs.existsSync(repoConfig.path())) {
+  if (!repoConfig.graphiteInitialized()) {
     logInfo("Welcome to Graphite!");
   } else {
-    logInfo(`Regenerating "${repoConfig.path()}"`);
+    logInfo(`Regenerating Graphite repo config (${repoConfig.path()})`);
   }
 }
 

--- a/src/lib/config/repo_config.ts
+++ b/src/lib/config/repo_config.ts
@@ -28,6 +28,10 @@ type RepoConfigT = {
 class RepoConfig {
   _data: RepoConfigT;
 
+  public graphiteInitialized(): boolean {
+    return fs.existsSync(CURRENT_REPO_CONFIG_PATH);
+  }
+
   constructor(data: RepoConfigT) {
     this._data = data;
   }

--- a/src/lib/telemetry/profile.ts
+++ b/src/lib/telemetry/profile.ts
@@ -20,6 +20,7 @@ import {
 import {
   logError,
   logInfo,
+  logNewline,
   logWarn,
   parseArgs,
   VALIDATION_HELPER_MESSAGE,
@@ -37,6 +38,8 @@ export async function profile(
   registerSigintHandler({ commandName: parsedArgs.command, startTime: start });
 
   if (parsedArgs.command !== "repo init" && !repoConfig.getTrunk()) {
+    logInfo(`Graphite has not been initialized, attempting to setup now...`);
+    logNewline();
     await init();
   }
 

--- a/src/lib/telemetry/upgrade_prompt.ts
+++ b/src/lib/telemetry/upgrade_prompt.ts
@@ -6,7 +6,7 @@ import cp from "child_process";
 import { getUserEmail, SHOULD_REPORT_TELEMETRY } from ".";
 import { version } from "../../../package.json";
 import { API_SERVER } from "../api";
-import { messageConfig } from "../config";
+import { messageConfig, repoConfig } from "../config";
 
 function printAndClearOldMessage(): void {
   const oldMessage = messageConfig.getMessage();
@@ -19,6 +19,10 @@ function printAndClearOldMessage(): void {
   }
 }
 export function fetchUpgradePromptInBackground(): void {
+  if (!repoConfig.graphiteInitialized()) {
+    return;
+  }
+
   printAndClearOldMessage();
   cp.spawn("/usr/bin/env", ["node", __filename], {
     detached: true,


### PR DESCRIPTION
**Context:**

The welcome message is broken right now because:
- we show the message if the repo config file does not exist
- we have multiple background commands that race and write repo config

**Changes In This Pull Request:**

This PR fixes the message by:
- standardizing the way we check whether Graphite has been initialized (in a single method)
- having these other background fetches only fetch if Graphite has been initialized

**Test Plan:**

welcome message is now shown in an empty repo

