### PR TITLE
[Submit] Infer body from commit message

### DIFF
--- a/src/actions/print_stack.ts
+++ b/src/actions/print_stack.ts
@@ -121,7 +121,7 @@ function getBranchInfo(branch: Branch, config: TPrintStackConfig): string[] {
       commits.forEach((commitSHA) => {
         const commit = new Commit(commitSHA);
         branchInfoLines.push(
-          chalk.gray(`* ${commit.sha.slice(0, 6)} - ${commit.message()}`)
+          chalk.gray(`* ${commit.sha.slice(0, 6)} - ${commit.messageSubject()}`)
         );
       });
     }

--- a/src/actions/submit.ts
+++ b/src/actions/submit.ts
@@ -12,18 +12,18 @@ import {
   ExitFailedError,
   KilledError,
   PreconditionsFailedError,
-  ValidationFailedError
+  ValidationFailedError,
 } from "../lib/errors";
 import {
   cliAuthPrecondition,
-  currentBranchPrecondition
+  currentBranchPrecondition,
 } from "../lib/preconditions";
 import {
   gpExecSync,
   logError,
   logInfo,
   logNewline,
-  logSuccess
+  logSuccess,
 } from "../lib/utils";
 import { getDefaultEditor } from "../lib/utils/default_editor";
 import { getPRTemplate } from "../lib/utils/pr_templates";
@@ -353,7 +353,10 @@ async function getPRCreationInfo(args: {
     title = response.title ?? title;
   }
 
-  let body = await getPRTemplate();
+  const template = await getPRTemplate();
+  const inferredBodyFromCommit = inferPRBody(args.branch);
+  let body =
+    inferredBodyFromCommit !== null ? inferredBodyFromCommit : template;
   const hasPRTemplate = body !== undefined;
   if (args.editPRFieldsInline) {
     const defaultEditor = getDefaultEditor();
@@ -418,24 +421,36 @@ async function getPRCreationInfo(args: {
   };
 }
 
-function inferPRTitle(branch: Branch) {
+export function inferPRTitle(branch: Branch): string {
   // Only infer the title from the commit if the branch has just 1 commit.
-  const singleCommitMessage = getSingleCommitMessageOnBranch(branch);
-  if (singleCommitMessage !== null) {
-    return singleCommitMessage;
-  }
+  const singleCommit = getSingleCommitOnBranch(branch);
+  const singleCommitSubject =
+    singleCommit === null ? null : singleCommit.messageSubject().trim();
 
+  if (singleCommitSubject !== null && singleCommitSubject.length > 0) {
+    return singleCommitSubject;
+  }
   return `Merge ${branch.name} into ${branch.getParentFromMeta()!.name}`;
 }
 
-function getSingleCommitMessageOnBranch(branch: Branch): string | null {
+export function inferPRBody(branch: Branch): string | null {
+  // Only infer the title from the commit if the branch has just 1 commit.
+  const singleCommit = getSingleCommitOnBranch(branch);
+  const singleCommitBody =
+    singleCommit === null ? null : singleCommit.messageBody().trim();
+
+  if (singleCommitBody !== null && singleCommitBody.length > 0) {
+    return singleCommitBody;
+  }
+  return null;
+}
+
+function getSingleCommitOnBranch(branch: Branch): Commit | null {
   const commits = branch.getCommitSHAs();
   if (commits.length !== 1) {
     return null;
   }
-  const commit = new Commit(commits[0]);
-  const commitMessage = commit.message();
-  return commitMessage.length > 0 ? commitMessage : null;
+  return new Commit(commits[0]);
 }
 
 async function editPRBody(args: {

--- a/src/wrapper-classes/commit.ts
+++ b/src/wrapper-classes/commit.ts
@@ -25,10 +25,10 @@ export default class Commit {
     }
   }
 
-  public message(): string {
+  private messageImpl(format: "B" | "b" | "s"): string {
     const message = gpExecSync(
       {
-        command: `git log --format=%s -n 1 ${this.sha}`,
+        command: `git log --format=%${format} -n 1 ${this.sha}`,
       },
       (_) => {
         // just soft-fail if we can't find the commits
@@ -38,5 +38,17 @@ export default class Commit {
       .toString()
       .trim();
     return message;
+  }
+
+  public messageRaw(): string {
+    return this.messageImpl("B");
+  }
+
+  public messageSubject(): string {
+    return this.messageImpl("s");
+  }
+
+  public messageBody(): string {
+    return this.messageImpl("b");
   }
 }

--- a/test/fast/actions/submit_action.test.ts
+++ b/test/fast/actions/submit_action.test.ts
@@ -1,0 +1,53 @@
+import { expect } from "chai";
+import { execSync } from "child_process";
+import { inferPRBody, inferPRTitle } from "../../../src/actions/submit";
+import { Branch } from "../../../src/wrapper-classes";
+import { BasicScene } from "../../lib/scenes";
+import { configureTest } from "../../lib/utils";
+
+for (const scene of [new BasicScene()]) {
+  describe(`(${scene}): correctly infers submit info from commits`, function () {
+    configureTest(this, scene);
+
+    it("can infer title/body from single commit", async () => {
+      const title = "Test Title";
+      const body = ["Test body line 1.", "Test body line 2."].join("\n");
+
+      scene.repo.execCliCommand(`branch create "a" -q`);
+      scene.repo.createChange("a");
+      execSync(`git commit -m "${title}" -m "${body}"`);
+
+      const branch = await Branch.branchWithName("a");
+
+      expect(inferPRTitle(branch)).to.equals(title);
+      expect(inferPRBody(branch)).to.equals(body);
+    });
+
+    it("can infer just title with no body", async () => {
+      const title = "Test Title";
+
+      const commitMessage = `${title}`;
+
+      scene.repo.createChange("a");
+      scene.repo.execCliCommand(`branch create "a" -m "${commitMessage}" -q`);
+
+      const branch = await Branch.branchWithName("a");
+      expect(inferPRTitle(branch)).to.equals(title);
+      expect(inferPRBody(branch)).to.be.null;
+    });
+
+    it("does not infer title/body for multiple commits", async () => {
+      const title = "Test Title";
+
+      const commitMessage = `${title}`;
+
+      scene.repo.createChange("a");
+      scene.repo.execCliCommand(`branch create "a" -m "${commitMessage}" -q`);
+      scene.repo.createChangeAndCommit(commitMessage);
+
+      const branch = await Branch.branchWithName("a");
+      expect(inferPRTitle(branch)).to.not.equals(title);
+      expect(inferPRBody(branch)).to.be.null;
+    });
+  });
+}


### PR DESCRIPTION
This PR allows the CLI to parse the submit message from a multi-line commit.

(new to me) Git itself parses its commit messages with a 'subject' and a 'body'. So far, our commit message logic has just extracted the 'subject' (aka the title) of the commit.

This PR 1) adds support for grabbing the 'body' and 2) hooks that up to our submit logic.

This PR was authored and submitted with this new functionality.