### PR TITLE
[Commit Create] Allow editing without -m

### DIFF
--- a/src/actions/commit_create.ts
+++ b/src/actions/commit_create.ts
@@ -9,7 +9,7 @@ import { fixAction } from "./fix";
 
 export async function commitCreateAction(opts: {
   addAll: boolean;
-  message: string;
+  message: string | undefined;
 }): Promise<void> {
   if (opts.addAll) {
     gpExecSync(
@@ -24,18 +24,35 @@ export async function commitCreateAction(opts: {
 
   ensureSomeStagedChangesPrecondition();
 
-  gpExecSync(
-    {
-      command: [
-        "git commit",
-        `-m "${opts.message}"`,
-        ...[execStateConfig.noVerify() ? ["--no-verify"] : []],
-      ].join(" "),
-    },
-    (err) => {
-      throw new ExitFailedError("Failed to commit changes. Aborting...", err);
-    }
-  );
+  if (opts.message !== undefined) {
+    gpExecSync(
+      {
+        command: [
+          "git commit",
+          `-m ${opts.message}`,
+          ...[execStateConfig.noVerify() ? ["--no-verify"] : []],
+        ].join(" "),
+      },
+      (err) => {
+        throw new ExitFailedError("Failed to commit changes. Aborting...", err);
+      }
+    );
+  } else {
+    gpExecSync(
+      {
+        command: [
+          "git commit",
+          ...[execStateConfig.noVerify() ? ["--no-verify"] : []],
+        ].join(" "),
+        options: {
+          stdio: "inherit",
+        },
+      },
+      (err) => {
+        throw new ExitFailedError("Failed to commit changes. Aborting...", err);
+      }
+    );
+  }
 
   try {
     uncommittedChangesPrecondition();

--- a/src/commands/commit-commands/create.ts
+++ b/src/commands/commit-commands/create.ts
@@ -14,7 +14,7 @@ const args = {
     type: "string",
     alias: "m",
     describe: "The message for the new commit.",
-    required: true,
+    required: false,
   },
 } as const;
 


### PR DESCRIPTION
Some users have requested the ability to run `gt commit create` without specifying a message inline (instead launching their default editor to write the message).

This PR adds that logic.

Note that I added some code duplication given that I don't expect this code to be updated often and it makes things a bit more clear; the alternative was a bunch of ternaries around the message argument.