### PR TITLE
[Stack Fix] Memoize stack lookups

### DIFF
--- a/src/actions/fix.ts
+++ b/src/actions/fix.ts
@@ -13,10 +13,10 @@ import {
 } from "../lib/preconditions";
 import {
   checkoutBranch,
+  getTrunk,
   gpExecSync,
   logInfo,
   rebaseInProgress,
-  getTrunk,
 } from "../lib/utils";
 import {
   Branch,
@@ -79,8 +79,12 @@ export async function fixAction(opts: {
   const currentBranch = currentBranchPrecondition();
   uncommittedChangesPrecondition();
 
-  const metaStack = new MetaStackBuilder().fullStackFromBranch(currentBranch);
-  const gitStack = new GitStackBuilder().fullStackFromBranch(currentBranch);
+  const metaStack = new MetaStackBuilder({
+    useMemoizedResults: true,
+  }).fullStackFromBranch(currentBranch);
+  const gitStack = new GitStackBuilder({
+    useMemoizedResults: true,
+  }).fullStackFromBranch(currentBranch);
 
   // Consider noop
   if (metaStack.equals(gitStack)) {


### PR DESCRIPTION
Addressing some perf issues, anywhere where we're just doing read operations in stack fix (e.g. determining what the meta and git stacks look like), we can use memoized data.

This PR turns those settings on.

The operations we need to be careful on are the regen/upstack side of things, but all of these lines should avoid that since we cleanly 1) determine the shape of the stacks 2) ask for input 3) *then* take the necessary action.