### PR TITLE
[Commit Create] Fix

### DIFF
--- a/src/actions/commit_create.ts
+++ b/src/actions/commit_create.ts
@@ -2,7 +2,7 @@ import { execStateConfig } from "../lib/config";
 import { ExitFailedError } from "../lib/errors";
 import {
   ensureSomeStagedChangesPrecondition,
-  uncommittedChangesPrecondition,
+  uncommittedChangesPrecondition
 } from "../lib/preconditions";
 import { gpExecSync, logWarn } from "../lib/utils";
 import { fixAction } from "./fix";
@@ -29,7 +29,7 @@ export async function commitCreateAction(opts: {
       {
         command: [
           "git commit",
-          `-m ${opts.message}`,
+          `-m "${opts.message}"`,
           ...[execStateConfig.noVerify() ? ["--no-verify"] : []],
         ].join(" "),
       },

--- a/test/fast/commands/commit/create.test.ts
+++ b/test/fast/commands/commit/create.test.ts
@@ -14,6 +14,14 @@ for (const scene of allScenes) {
       expectCommits(scene.repo, "2, 1");
     });
 
+    it("Can create a commit with a multi-word commit message", () => {
+      scene.repo.createChange("2");
+      scene.repo.execCliCommand(`commit create -m "a b c" -q`);
+
+      expect(scene.repo.currentBranchName()).to.equal("main");
+      expectCommits(scene.repo, "a b c");
+    });
+
     it("Fails to create a commit if there are no staged changes", () => {
       expect(() =>
         scene.repo.execCliCommand(`commit create -m "a" -q`)


### PR DESCRIPTION
Forgot to add quotes around the commit message; adding to fix multi-word commit messages.

