### PR TITLE
Infer self-hosted repo info

### DIFF
--- a/src/lib/config/repo_config.ts
+++ b/src/lib/config/repo_config.ts
@@ -231,8 +231,8 @@ function getOwnerAndNameFromURL(originURL: string): {
     url = url.slice(0, -".git".length);
   }
 
-  if (url.startsWith("git@github.com")) {
-    regex = /git@github.com:([^/]+)\/(.+)/;
+  if (url.startsWith("git@")) {
+    regex = /git@[^:]+:([^/]+)\/(.+)/;
   } else if (url.startsWith("https://")) {
     regex = /https:\/\/github.com\/([^/]+)\/(.+)/;
   } else {

--- a/test/fast/commands/repo_config/repo_config.test.ts
+++ b/test/fast/commands/repo_config/repo_config.test.ts
@@ -38,5 +38,13 @@ for (const scene of [new BasicScene()]) {
       expect(sshClone.owner === "screenplaydev").to.be.true;
       expect(sshClone.name === "graphite-cli").to.be.true;
     });
+
+    it("Can infer a self-hosted .git repo", () => {
+      const { owner, name } = getOwnerAndNameFromURLForTesting(
+        "git@dub.duckduckgo.com:duckduckgo/Android-Vpn.git"
+      );
+      expect(owner === 'duckduckgo').to.be.true;
+      expect(name === 'Android-Vpn').to.be.true;
+    })
   });
 }


### PR DESCRIPTION
**Context:**

Earlier, we failed to parse the correct repo owner and name information from the URL git@dub.duckduckgo.com:duckduckgo/Android-Vpn.git.

**Changes In This Pull Request:**

This PR adds support for this type of URL and adds a test to enforce the support.

**Test Plan:**

test included in PR
