### PR TITLE
[Branch Create] Clear any previous, stale metadata

### DIFF
--- a/src/actions/create_branch.ts
+++ b/src/actions/create_branch.ts
@@ -10,18 +10,20 @@ import Branch from "../wrapper-classes/branch";
 export async function createBranchAction(opts: {
   branchName?: string;
   commitMessage?: string;
-  addAll?: boolean
+  addAll?: boolean;
 }): Promise<void> {
   const parentBranch = currentBranchPrecondition();
 
   if (opts.addAll) {
     gpExecSync(
-        {
-          command: "git add --all",
-        },
-        () => {
-          throw new ExitFailedError("Could not add all staged changes. Aborting...");
-        }
+      {
+        command: "git add --all",
+      },
+      () => {
+        throw new ExitFailedError(
+          "Could not add all staged changes. Aborting..."
+        );
+      }
     );
   }
 
@@ -72,7 +74,9 @@ export async function createBranchAction(opts: {
     );
   }
 
-  new Branch(branchName).setParentBranchName(parentBranch.name);
+  // If the branch previously existed and the stale metadata is still around,
+  // make sure that we wipe that stale metadata.
+  new Branch(branchName).clearMetadata().setParentBranchName(parentBranch.name);
 }
 
 function newBranchName(branchName?: string, commitMessage?: string): string {

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -221,6 +221,11 @@ export default class Branch {
     return execSync(`git rev-parse ${this.name}`).toString().trim();
   }
 
+  public clearMetadata(): this {
+    this.writeMeta({});
+    return this;
+  }
+
   public clearParentMetadata(): void {
     const meta: TMeta = this.getMeta() || {};
     delete meta.parentBranchName;


### PR DESCRIPTION
**Context:**

Users were hitting an issue where:
1. they created a branch and submitted it
2. they deleted the branch (`git branch -D`)
3. they created a new branch of the same name -- and Graphite incorrectly connected the old PR to said branch
 
The root cause here is that the Graphite metadata for the branch isn't being deleted between steps 2 and 3 (the only command that deletes metadata today is `gt repo sync`).

**Changes In This Pull Request:**

This PR changes create branch to clear any branch metadata before setting the new branch metadata.

**Test Plan:**

test included

