### PR TITLE
abc

### DIFF
--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -8,7 +8,11 @@ import {
 } from "../lib/git-refs";
 import { getCommitterDate, getTrunk, gpExecSync, logDebug } from "../lib/utils";
 import Commit from "./commit";
-import MetadataRef, { TBranchPRInfo, TMeta } from "./metadata_ref";
+import MetadataRef, {
+  TBranchPRInfo,
+  TBranchSubmitInfo,
+  TMeta,
+} from "./metadata_ref";
 
 type TBranchFilters = {
   useMemoizedResults?: boolean;
@@ -465,6 +469,16 @@ export default class Branch {
 
   public branchesWithSameCommit(): Branch[] {
     return otherBranchesWithSameCommit(this);
+  }
+
+  public setSubmitInfo(submitInfo: TBranchSubmitInfo): void {
+    const meta: TMeta = this.getMeta() || {};
+    meta.submitInfo = submitInfo;
+    this.writeMeta(meta);
+  }
+
+  public getSubmitInfo(): TBranchSubmitInfo | undefined {
+    return this.getMeta()?.submitInfo;
   }
 
   public setPRInfo(prInfo: TBranchPRInfo): void {

--- a/src/wrapper-classes/metadata_ref.ts
+++ b/src/wrapper-classes/metadata_ref.ts
@@ -19,10 +19,16 @@ export type TBranchPRInfo = {
   isDraft?: boolean;
 };
 
+export type TBranchSubmitInfo = {
+  title?: string;
+  body?: string;
+};
+
 export type TMeta = {
   parentBranchName?: string;
   prevRef?: string;
   prInfo?: TBranchPRInfo;
+  submitInfo?: TBranchSubmitInfo;
 };
 
 export default class MetadataRef {


### PR DESCRIPTION
**Context:**

Right now, if submit crashes, we don't save any of the title or body information you may have entered (which may be paragraphs in the worst case).

This is a bad experience.

**Changes In This Pull Request:**

This PR saves your entered title and body, immediately after you enter each, on the branch metadata.

**Test Plan:**

killed submit after entering title and body; next invocation had both prepopulated

