### PR TITLE
[Submit] Save state if submit exits early

### DIFF
--- a/src/actions/submit/pr_body.ts
+++ b/src/actions/submit/pr_body.ts
@@ -61,6 +61,11 @@ async function editPRBody(args: {
 }
 
 export function inferPRBody(branch: Branch): string | null {
+  const priorSubmitBody = branch.getPriorSubmitBody();
+  if (priorSubmitBody !== undefined) {
+    return priorSubmitBody;
+  }
+
   // Only infer the title from the commit if the branch has just 1 commit.
   const singleCommit = getSingleCommitOnBranch(branch);
   const singleCommitBody =

--- a/src/actions/submit/pr_title.ts
+++ b/src/actions/submit/pr_title.ts
@@ -28,6 +28,11 @@ export async function getPRTitle(args: {
 }
 
 export function inferPRTitle(branch: Branch): string {
+  const priorSubmitTitle = branch.getPriorSubmitTitle();
+  if (priorSubmitTitle !== undefined) {
+    return priorSubmitTitle;
+  }
+
   // Only infer the title from the commit if the branch has just 1 commit.
   const singleCommit = getSingleCommitOnBranch(branch);
   const singleCommitSubject =

--- a/src/actions/submit/submit.ts
+++ b/src/actions/submit/submit.ts
@@ -346,10 +346,14 @@ async function getPRCreationInfo(args: {
     branch: args.branch,
     editPRFieldsInline: args.editPRFieldsInline,
   });
+  args.branch.setPriorSubmitTitle(title);
+
   const body = await getPRBody({
     branch: args.branch,
     editPRFieldsInline: args.editPRFieldsInline,
   });
+  args.branch.setPriorSubmitBody(body);
+
   const createAsDraft = await getPRDraftStatus({
     createNewPRsAsDraft: args.createNewPRsAsDraft,
   });

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -467,6 +467,32 @@ export default class Branch {
     return otherBranchesWithSameCommit(this);
   }
 
+  public setPriorSubmitTitle(title: string): void {
+    const meta: TMeta = this.getMeta() || {};
+    meta.priorSubmitInfo = {
+      ...meta.priorSubmitInfo,
+      title: title,
+    };
+    this.writeMeta(meta);
+  }
+
+  public getPriorSubmitTitle(): string | undefined {
+    return this.getMeta()?.priorSubmitInfo?.title;
+  }
+
+  public setPriorSubmitBody(body: string): void {
+    const meta: TMeta = this.getMeta() || {};
+    meta.priorSubmitInfo = {
+      ...meta.priorSubmitInfo,
+      body: body,
+    };
+    this.writeMeta(meta);
+  }
+
+  public getPriorSubmitBody(): string | undefined {
+    return this.getMeta()?.priorSubmitInfo?.body;
+  }
+
   public setPRInfo(prInfo: TBranchPRInfo): void {
     const meta: TMeta = this.getMeta() || {};
     meta.prInfo = prInfo;

--- a/src/wrapper-classes/metadata_ref.ts
+++ b/src/wrapper-classes/metadata_ref.ts
@@ -19,10 +19,16 @@ export type TBranchPRInfo = {
   isDraft?: boolean;
 };
 
+export type TBranchPriorSubmitInfo = {
+  title?: string;
+  body?: string;
+};
+
 export type TMeta = {
   parentBranchName?: string;
   prevRef?: string;
   prInfo?: TBranchPRInfo;
+  priorSubmitInfo?: TBranchPriorSubmitInfo;
 };
 
 export default class MetadataRef {


### PR DESCRIPTION
**Context:**

Right now, if submit crashes, we don't save any of the title or body information you may have entered (which may be paragraphs in the worst case).

This is a bad experience.

**Changes In This Pull Request:**

This PR saves your entered title and body, immediately after you enter each, on the branch metadata.

**Test Plan:**

killed submit after entering title and body; next invocation had both prepopulated


