### PR TITLE
[Survey] Only show survey when server tells CLI to

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/screenplaydev/screenplay-cli",
   "private": true,
   "dependencies": {
-    "@screenplaydev/graphite-cli-routes": "0.11.0",
+    "@screenplaydev/graphite-cli-routes": "0.13.0",
     "@screenplaydev/retype": "^0.2.0",
     "@screenplaydev/retyped-routes": "^0.1.0",
     "chalk": "^4.1.0",

--- a/src/actions/fix.ts
+++ b/src/actions/fix.ts
@@ -20,12 +20,12 @@ import {
   rebaseInProgress,
 } from "../lib/utils";
 import {
-  Branch,
   GitStackBuilder,
   MetaStackBuilder,
   Stack,
   StackNode,
 } from "../wrapper-classes";
+import Branch from "../wrapper-classes/branch";
 
 async function promptStacks(opts: {
   gitStack: Stack;

--- a/src/actions/validate.ts
+++ b/src/actions/validate.ts
@@ -1,12 +1,8 @@
 import { ValidationFailedError } from "../lib/errors";
 import { currentBranchPrecondition } from "../lib/preconditions";
 import { logInfo } from "../lib/utils";
-import {
-  Branch,
-  GitStackBuilder,
-  MetaStackBuilder,
-  Stack,
-} from "../wrapper-classes";
+import { GitStackBuilder, MetaStackBuilder, Stack } from "../wrapper-classes";
+import Branch from "../wrapper-classes/branch";
 import { TScope } from "./scope";
 
 export function validate(scope: TScope): void {

--- a/src/commands/autocomplete.ts
+++ b/src/commands/autocomplete.ts
@@ -1,5 +1,5 @@
 import yargs, { Arguments } from "yargs";
-import { Branch } from "../wrapper-classes";
+import Branch from "../wrapper-classes/branch";
 
 yargs.completion("completion", (current, argv) => {
   const branchArg = getBranchArg(current, argv);
@@ -30,7 +30,11 @@ function getBranchArg(current: string, argv: Arguments): string | null {
   const currentCommand = argv["_"].join(" ");
 
   // gt branch checkout --branch <branch_name>
-  if ((currentCommand.includes("branch checkout") || currentCommand.includes("b checkout")) && "branch" in argv) {
+  if (
+    (currentCommand.includes("branch checkout") ||
+      currentCommand.includes("b checkout")) &&
+    "branch" in argv
+  ) {
     // Because --branch is an option on the overall command, we need to check
     // the value of current to make sure that the branch argument is the
     // current argument being entered by the user.
@@ -46,12 +50,19 @@ function getBranchArg(current: string, argv: Arguments): string | null {
   // a substring of another command). Since we're dealing with a positional,
   // we also want to make sure that the current argument is the positional
   // (position 3).
-  if (argv["_"].includes("bco") && argv["_"].length <= 3 && typeof current === "string") {
+  if (
+    argv["_"].includes("bco") &&
+    argv["_"].length <= 3 &&
+    typeof current === "string"
+  ) {
     return current;
   }
 
   // gt upstack onto <branch_name>
-  if (currentCommand.includes("upstack onto") || currentCommand.includes("us onto")) {
+  if (
+    currentCommand.includes("upstack onto") ||
+    currentCommand.includes("us onto")
+  ) {
     // Again, since we're detailing with a positional, we want to make sure
     // that the current argument being entered is in the desired position,
     // i.e. position 4.

--- a/src/commands/branch-commands/rename.ts
+++ b/src/commands/branch-commands/rename.ts
@@ -5,7 +5,8 @@ import { ExitFailedError } from "../../lib/errors";
 import { currentBranchPrecondition } from "../../lib/preconditions";
 import { profile } from "../../lib/telemetry";
 import { gpExecSync, logInfo } from "../../lib/utils";
-import { Branch, MetadataRef } from "../../wrapper-classes";
+import { MetadataRef } from "../../wrapper-classes";
+import Branch from "../../wrapper-classes/branch";
 
 const args = {
   "new-branch-name": {

--- a/src/commands/repo-commands/ignored_branches.ts
+++ b/src/commands/repo-commands/ignored_branches.ts
@@ -3,7 +3,7 @@ import { repoConfig } from "../../lib/config";
 import { PreconditionsFailedError } from "../../lib/errors";
 import { profile } from "../../lib/telemetry";
 import { logInfo } from "../../lib/utils";
-import { Branch } from "../../wrapper-classes";
+import Branch from "../../wrapper-classes/branch";
 
 const args = {
   add: {

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -1,4 +1,5 @@
-import { Branch } from "../../wrapper-classes";
+import Branch from "../../wrapper-classes/branch";
+
 class ExitError extends Error {}
 class ExitCancelledError extends ExitError {
   constructor(message: string) {

--- a/src/lib/telemetry/survey.ts
+++ b/src/lib/telemetry/survey.ts
@@ -1,0 +1,172 @@
+import graphiteCLIRoutes from "@screenplaydev/graphite-cli-routes";
+import { default as t } from "@screenplaydev/retype";
+import { request } from "@screenplaydev/retyped-routes";
+import prompts from "prompts";
+import { API_SERVER } from "../../lib/api";
+import { cliAuthPrecondition } from "../../lib/preconditions";
+import { logMessageFromGraphite, logNewline } from "../utils";
+
+export type SurveyT = t.UnwrapSchemaMap<
+  typeof graphiteCLIRoutes.cliSurvey.response
+>["survey"];
+
+export async function getSurvey(): Promise<SurveyT | undefined> {
+  try {
+    const authToken = cliAuthPrecondition();
+    const response = await request.requestWithArgs(
+      API_SERVER,
+      graphiteCLIRoutes.cliSurvey,
+      {},
+      { authToken: authToken }
+    );
+    if (response._response.status === 200) {
+      return response.survey;
+    }
+  } catch (e) {
+    // silence any error - this shouldn't crash any part of the CLI
+  }
+
+  // If we didn't get a definitive answer, let's be conservative and err on
+  // the side of *not* showing the survey in potentially incorrect situations.
+  return undefined;
+}
+
+class ExitedSurveyError extends Error {
+  constructor() {
+    super(`User exited Graphite survey early`);
+    this.name = "Killed";
+  }
+}
+
+export type SurveyResponseT = {
+  timestamp: number;
+  responses: { [question: string]: string };
+  exitedEarly: boolean;
+};
+
+export async function showSurvey(survey: SurveyT): Promise<void> {
+  const responses: SurveyResponseT = {
+    timestamp: Date.now(),
+    responses: {},
+    exitedEarly: false,
+  };
+  try {
+    if (survey === undefined) {
+      return;
+    }
+
+    logNewline();
+    if (survey?.introMessage !== undefined) {
+      logMessageFromGraphite(survey.introMessage);
+    }
+
+    logNewline();
+    await askSurveyQuestions({
+      questions: survey.questions,
+      responses: responses,
+    });
+
+    logNewline();
+    await logAnswers({
+      responses: responses,
+      completionMessage: survey?.completionMessage,
+    });
+  } catch (err) {
+    switch (err.constructor) {
+      case ExitedSurveyError:
+        responses.exitedEarly = true;
+        logNewline();
+        await logAnswers({
+          responses: responses,
+          completionMessage: survey?.completionMessage,
+        });
+        break;
+      default:
+        throw err;
+    }
+  }
+}
+
+/**
+ * While capturing the responses, mutate the passed-in object so we can always
+ * capture and potential responses before the user decided to exit the survey
+ * early.
+ */
+async function askSurveyQuestions(args: {
+  questions: (
+    | {
+        type: "TEXT";
+        question: string;
+      }
+    | {
+        type: "OPTIONS";
+        question: string;
+        options: string[];
+      }
+  )[];
+  responses: SurveyResponseT;
+}): Promise<void> {
+  for (const [index, question] of args.questions.entries()) {
+    const onCancel = {
+      onCancel: () => {
+        throw new ExitedSurveyError();
+      },
+    };
+
+    let promptResponse;
+    const questionText = `Question [${index + 1}/${args.questions.length}]: ${
+      question.question
+    }`;
+
+    switch (question.type) {
+      case "TEXT":
+        promptResponse = await prompts(
+          {
+            type: "text",
+            name: "answer",
+            message: questionText,
+          },
+          onCancel
+        );
+        break;
+      case "OPTIONS":
+        promptResponse = await prompts(
+          {
+            type: "select",
+            name: "answer",
+            message: questionText,
+            choices: question.options.map((option) => {
+              return {
+                title: option,
+                value: option,
+              };
+            }),
+          },
+          onCancel
+        );
+        break;
+      default:
+        assertUnreachable(question);
+        continue;
+    }
+
+    // Add newline after each response to create visual separation to next
+    // question.
+    logNewline();
+
+    args.responses.responses[question.question] = promptResponse.answer;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function assertUnreachable(arg: never): void {}
+
+async function logAnswers(args: {
+  responses: SurveyResponseT;
+  completionMessage: string | undefined;
+}): Promise<void> {
+  if (args.completionMessage !== undefined) {
+    logMessageFromGraphite(args.completionMessage);
+  }
+  return;
+}

--- a/src/lib/utils/single_commit.ts
+++ b/src/lib/utils/single_commit.ts
@@ -1,4 +1,5 @@
-import { Branch, Commit } from "../../wrapper-classes";
+import { Commit } from "../../wrapper-classes";
+import Branch from "../../wrapper-classes/branch";
 
 export function getSingleCommitOnBranch(branch: Branch): Commit | null {
   const commits = branch.getCommitSHAs();

--- a/src/wrapper-classes/git_stack_builder.ts
+++ b/src/wrapper-classes/git_stack_builder.ts
@@ -1,5 +1,6 @@
-import { AbstractStackBuilder, Branch } from ".";
+import { AbstractStackBuilder } from ".";
 import { MultiParentError, SiblingBranchError } from "../lib/errors";
+import Branch from "./branch";
 
 export default class GitStackBuilder extends AbstractStackBuilder {
   protected getBranchParent(branch: Branch): Branch | undefined {

--- a/src/wrapper-classes/index.ts
+++ b/src/wrapper-classes/index.ts
@@ -1,5 +1,4 @@
 import AbstractStackBuilder from "./abstract_stack_builder";
-import Branch from "./branch";
 import Commit from "./commit";
 import GitStackBuilder from "./git_stack_builder";
 import MetadataRef from "./metadata_ref";
@@ -12,7 +11,6 @@ export {
   AbstractStackBuilder,
   GitStackBuilder,
   MetaStackBuilder,
-  Branch,
   Commit,
   StackNode,
   MetadataRef,

--- a/test/fast/actions/submit_action.test.ts
+++ b/test/fast/actions/submit_action.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { execSync } from "child_process";
 import { inferPRBody, inferPRTitle } from "../../../src/actions/submit";
-import { Branch } from "../../../src/wrapper-classes";
+import Branch from "../../../src/wrapper-classes/branch";
 import { BasicScene } from "../../lib/scenes";
 import { configureTest } from "../../lib/utils";
 

--- a/test/fast/commands/branch/branch_create.test.ts
+++ b/test/fast/commands/branch/branch_create.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Branch } from "../../../../src/wrapper-classes";
+import Branch from "../../../../src/wrapper-classes/branch";
 import { allScenes } from "../../../lib/scenes";
 import { configureTest } from "../../../lib/utils";
 

--- a/test/fast/commands/branch/branch_delete.test.ts
+++ b/test/fast/commands/branch/branch_delete.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
-import { Branch, MetadataRef } from "../../../../src/wrapper-classes";
+import { MetadataRef } from "../../../../src/wrapper-classes";
+import Branch from "../../../../src/wrapper-classes/branch";
 import { allScenes } from "../../../lib/scenes";
 import { configureTest } from "../../../lib/utils";
 import { expectBranches } from "../../../lib/utils/expect_branches";

--- a/test/fast/commands/stack/fix.test.ts
+++ b/test/fast/commands/stack/fix.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Branch } from "../../../../src/wrapper-classes";
+import Branch from "../../../../src/wrapper-classes/branch";
 import { allScenes } from "../../../lib/scenes";
 import { configureTest, expectCommits } from "../../../lib/utils";
 

--- a/test/fast/wrapper-classes/stack_builder.test.ts
+++ b/test/fast/wrapper-classes/stack_builder.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "chai";
 import { SiblingBranchError } from "../../../src/lib/errors";
 import {
-  Branch,
   GitStackBuilder,
   MetaStackBuilder,
   Stack,
 } from "../../../src/wrapper-classes";
+import Branch from "../../../src/wrapper-classes/branch";
 import { allScenes } from "../../lib/scenes";
 import { configureTest } from "../../lib/utils";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,14 +294,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@screenplaydev/graphite-cli-routes@npm:0.11.0":
-  version: 0.11.0
-  resolution: "@screenplaydev/graphite-cli-routes@npm:0.11.0"
+"@screenplaydev/graphite-cli-routes@npm:0.13.0":
+  version: 0.13.0
+  resolution: "@screenplaydev/graphite-cli-routes@npm:0.13.0"
   dependencies:
     "@screenplaydev/retype": ^0.2.0
     "@screenplaydev/retyped-routes": ^0.1.0
     "@types/node": ^14.14.37
-  checksum: 18dfb960e1897b7c1f81ccc4b1daddae19277de6f082c4b92e79610dee9511578dcedbfe7ebdd14bdf12a07cb5b6a03cfdb50a55baeb8f8cecb5667ee92908a1
+  checksum: c4620cb0b72f64d66bc8d35a91a276df4782c059fa7038e3880a6e9af77bcece740222a46d2d7561bec8e5e42b09c4e9aa9fcf465e8b71295285370a270f70e0
   languageName: node
   linkType: hard
 
@@ -2258,7 +2258,7 @@ fsevents@~2.3.1:
   dependencies:
     "@commitlint/cli": ^13.1.0
     "@commitlint/config-conventional": ^13.1.0
-    "@screenplaydev/graphite-cli-routes": 0.11.0
+    "@screenplaydev/graphite-cli-routes": 0.13.0
     "@screenplaydev/retype": ^0.2.0
     "@screenplaydev/retyped-routes": ^0.1.0
     "@types/chai": ^4.2.14


### PR DESCRIPTION
Context:

The following stack is going to introduce a lot of the CLI logic that we'll use to query our users for feedback on the CLI.

Note that none of these tests will pass until I land corresponding changes to graphite-cli-routes.

**Changes In This Pull Request:**

This PR adds the logic that controls when the survey is shown to the user. After this change, during submit invocations, while posting the PRs, we simultaneously ask the server for the messages and questions we should show in our survey (and therefore, implicitly, whether a survey should be shown at all).

**Test Plan:**

yarn build, ran locally

