### PR TITLE
Fix parents in trace flame graphs

### DIFF
--- a/src/lib/telemetry/tracer.ts
+++ b/src/lib/telemetry/tracer.ts
@@ -82,7 +82,7 @@ export class Span {
       trace_id: traceId,
       type: "custom",
       duration: Math.round(currentNanoSeconds() - this.start),
-      ...(this.parentId ? { parent_id: this.parentId } : {}),
+      ...(this.parentId ? { parent_id: this.parentId } : { parent_id: 0 }),
     };
   }
 }


### PR DESCRIPTION
**Context:**

Right now, Datadog doesn't aggregate our traces.

**Changes In This Pull Request:**

After this PR, the traces accurately depict parent-child relationships (see attached photo), but all of the children are inexplicably located at the end of the parent timespan. I timeboxed an investigation into this last week and couldn't find anything, but putting up this fix as it's a net win.

**Test Plan:**

![image](https://user-images.githubusercontent.com/9063972/137031883-eaa892f0-1c20-4e7c-b61a-081c47db2862.png)
