### PR TITLE
[Continue] Support commit amend

### DIFF
--- a/src/actions/commit_amend.ts
+++ b/src/actions/commit_amend.ts
@@ -53,7 +53,7 @@ export async function commitAmendAction(opts: {
     uncommittedChangesPrecondition();
     await fixAction({
       action: "rebase",
-      mergeConflictCallstack: "MERGE_CONFLICT_CALLSTACK_TODO" as const,
+      mergeConflictCallstack: "TOP_OF_CALLSTACK_WITH_NOTHING_AFTER" as const,
     });
   } catch {
     logWarn(

--- a/src/commands/continue.ts
+++ b/src/commands/continue.ts
@@ -51,7 +51,7 @@ async function resolveCallstack(
   callstack: MergeConflictCallstackT
 ): Promise<void> {
   if (
-    callstack === "TOP_OF_CALLSTACK" ||
+    callstack === "TOP_OF_CALLSTACK_WITH_NOTHING_AFTER" ||
     callstack === "MERGE_CONFLICT_CALLSTACK_TODO"
   ) {
     return;

--- a/src/commands/stack-commands/fix.ts
+++ b/src/commands/stack-commands/fix.ts
@@ -35,7 +35,7 @@ export const handler = async (argv: argsT): Promise<void> => {
     }
     await fixAction({
       action: argv.rebase ? "rebase" : argv.regen ? "regen" : undefined,
-      mergeConflictCallstack: "TOP_OF_CALLSTACK",
+      mergeConflictCallstack: "TOP_OF_CALLSTACK_WITH_NOTHING_AFTER",
     });
   });
 };

--- a/src/lib/config/merge_conflict_callstack_config.ts
+++ b/src/lib/config/merge_conflict_callstack_config.ts
@@ -24,7 +24,7 @@ export type MergeConflictCallstackT =
       parent: MergeConflictCallstackT;
     }
   | "MERGE_CONFLICT_CALLSTACK_TODO"
-  | "TOP_OF_CALLSTACK";
+  | "TOP_OF_CALLSTACK_WITH_NOTHING_AFTER";
 
 type GraphiteFrameT = StackFixActionStackframeT | RestackNodeStackFrameT;
 

--- a/test/fast/commands/commit/amend_continue.test.ts
+++ b/test/fast/commands/commit/amend_continue.test.ts
@@ -1,0 +1,75 @@
+import { expect } from "chai";
+import { allScenes } from "../../../lib/scenes";
+import { configureTest, expectCommits } from "../../../lib/utils";
+
+for (const scene of allScenes) {
+  describe(`(${scene}): commit amend continue`, function () {
+    configureTest(this, scene);
+
+    it("Can continue a commit amend with single merge conflict", () => {
+      scene.repo.createChange("a");
+      scene.repo.execCliCommand("branch create 'a' -m 'a' -q");
+
+      scene.repo.createChange("b");
+      scene.repo.execCliCommand("branch create 'b' -m 'b' -q");
+
+      scene.repo.checkoutBranch("a");
+      scene.repo.createChange("1");
+
+      scene.repo.execCliCommand("commit amend -m 'c' -q");
+      expect(scene.repo.rebaseInProgress()).to.be.true;
+
+      scene.repo.resolveMergeConflicts();
+      scene.repo.markMergeConflictsAsResolved();
+      scene.repo.execCliCommand("continue --no-edit");
+
+      // Continue should finish the work that stack fix started, not only
+      // completing the rebase but also re-checking out the original
+      // branch.
+      expect(scene.repo.currentBranchName()).to.equal("a");
+      expectCommits(scene.repo, "c, 1");
+      expect(scene.repo.rebaseInProgress()).to.be.false;
+
+      // Expect that the stack was also put back together.
+      scene.repo.checkoutBranch("b");
+      expectCommits(scene.repo, "b, c");
+    });
+
+    it("Can run continue multiple times on a commit amend with multiple merge conflicts", () => {
+      scene.repo.createChange("a", "1");
+      scene.repo.createChange("a", "2");
+      scene.repo.execCliCommand("branch create 'a' -m 'a' -q");
+
+      scene.repo.createChange("b", "1");
+      scene.repo.execCliCommand("branch create 'b' -m 'b' -q");
+
+      scene.repo.createChange("c", "2");
+      scene.repo.execCliCommand("branch create 'c' -m 'c' -q");
+
+      scene.repo.checkoutBranch("a");
+      scene.repo.createChange("1", "1");
+      scene.repo.createChange("2", "2");
+      scene.repo.execCliCommand("commit amend -m 'a12' -q");
+
+      expect(scene.repo.rebaseInProgress()).to.be.true;
+      scene.repo.resolveMergeConflicts();
+      scene.repo.markMergeConflictsAsResolved();
+      scene.repo.execCliCommand("continue --no-edit");
+
+      expect(scene.repo.rebaseInProgress()).to.be.true;
+      scene.repo.resolveMergeConflicts();
+      scene.repo.markMergeConflictsAsResolved();
+      scene.repo.execCliCommand("continue --no-edit");
+
+      // Note that even though multiple continues have been run, the original
+      // context - that the original commit amend was kicked off at 'a' -
+      // should not be lost.
+      expect(scene.repo.currentBranchName()).to.equal("a");
+      expectCommits(scene.repo, "a12, 1");
+      expect(scene.repo.rebaseInProgress()).to.be.false;
+
+      scene.repo.checkoutBranch("c");
+      expectCommits(scene.repo, "c, b, a12");
+    });
+  });
+}


### PR DESCRIPTION
**Context:**

Now that we've walked through the setup for one command — `gt stack fix` — we're going to quickly run through the other callsites where a merge conflict can interrupt Graphite and a callstack needs to be persisted/continued.

These locations are:
* anywhere a stack fix is invoked under the hood
  * commit amend 
  * commit create
  * upstack onto
* anywhere an upstack onto is invoked under the hood
  * upstack onto 
  * repo fix (during branch deletion)
  * repo sync (during branch deletion)

**Changes In This Pull Request:**

This PR adds the new functionality for `gt commit amend` and adds a relevant test as well.

**Test Plan:**

test included

