### PR TITLE
[Continue] Persist callstack on merge conflict in stack fix

### DIFF
--- a/src/actions/commit_amend.ts
+++ b/src/actions/commit_amend.ts
@@ -51,7 +51,10 @@ export async function commitAmendAction(opts: {
   // Only restack if working tree is now clean.
   try {
     uncommittedChangesPrecondition();
-    await fixAction({ action: "rebase" });
+    await fixAction({
+      action: "rebase",
+      mergeConflictCallstack: "MERGE_CONFLICT_CALLSTACK_TODO" as const,
+    });
   } catch {
     logWarn(
       "Cannot fix upstack automatically, some uncommitted changes remain. Please commit or stash, and then `gt stack fix --rebase`"

--- a/src/actions/commit_create.ts
+++ b/src/actions/commit_create.ts
@@ -2,7 +2,7 @@ import { execStateConfig } from "../lib/config";
 import { ExitFailedError } from "../lib/errors";
 import {
   ensureSomeStagedChangesPrecondition,
-  uncommittedChangesPrecondition
+  uncommittedChangesPrecondition,
 } from "../lib/preconditions";
 import { gpExecSync, logWarn } from "../lib/utils";
 import { fixAction } from "./fix";
@@ -56,7 +56,10 @@ export async function commitCreateAction(opts: {
 
   try {
     uncommittedChangesPrecondition();
-    await fixAction({ action: "rebase" });
+    await fixAction({
+      action: "rebase",
+      mergeConflictCallstack: "MERGE_CONFLICT_CALLSTACK_TODO" as const,
+    });
   } catch {
     logWarn(
       "Cannot fix upstack automatically, some uncommitted changes remain. Please commit or stash, and then `gt stack fix --rebase`"

--- a/src/actions/onto.ts
+++ b/src/actions/onto.ts
@@ -65,7 +65,10 @@ async function stackOnto(currentBranch: Branch, onto: string) {
   currentBranch.setParentBranchName(onto);
 
   // Now perform a fix starting from the onto branch:
-  await restackBranch(currentBranch);
+  await restackBranch({
+    branch: currentBranch,
+    mergeConflictCallstack: "MERGE_CONFLICT_CALLSTACK_TODO" as const,
+  });
   logInfo(`Successfully moved (${currentBranch.name}) onto (${onto})`);
 }
 

--- a/src/commands/stack-commands/fix.ts
+++ b/src/commands/stack-commands/fix.ts
@@ -35,6 +35,7 @@ export const handler = async (argv: argsT): Promise<void> => {
     }
     await fixAction({
       action: argv.rebase ? "rebase" : argv.regen ? "regen" : undefined,
+      mergeConflictCallstack: "TOP_OF_CALLSTACK",
     });
   });
 };

--- a/src/lib/config/merge_conflict_callstack_config.ts
+++ b/src/lib/config/merge_conflict_callstack_config.ts
@@ -18,23 +18,25 @@ const CURRENT_REPO_CONFIG_PATH = path.join(getRepoRootPath(), CONFIG_NAME);
  * The below object helps keep track of these items and persist them across
  * invocations of the CLI.
  */
-export type MergeConflictCallstackT = {
-  interruptedRebase: InterruptedRebaseT;
-  rebaseContinuations: RebaseContinuationsT;
+export type MergeConflictCallstackT =
+  | {
+      frame: GraphiteFrameT;
+      parent: MergeConflictCallstackT;
+    }
+  | "MERGE_CONFLICT_CALLSTACK_TODO"
+  | "TOP_OF_CALLSTACK";
+
+type GraphiteFrameT = StackFixActionStackframeT | RestackNodeStackFrameT;
+
+export type StackFixActionStackframeT = {
+  op: "STACK_FIX_ACTION_CONTINUATION";
+  checkoutBranchName: string;
 };
 
-type InterruptedRebaseT = {
+export type RestackNodeStackFrameT = {
   op: "STACK_FIX";
-  sourceBranch: string;
+  sourceBranchName: string;
 };
-
-type RebaseContinuationMethodT = "STACK_FIX_CONTINUATION";
-
-type RebaseContinuationsT = {
-  method: RebaseContinuationMethodT;
-  args: any;
-  parent: RebaseContinuationsT;
-} | null;
 
 export function persistMergeConflictCallstack(
   callstack: MergeConflictCallstackT


### PR DESCRIPTION
**Context:**

Our overall goal in this stack of PRs is to introduce a gt continue command which can be a Graphite replacement for git rebase --continue when a merge conflict interrupts the execution of a Graphite command.

We plan to do this by essentially capturing the callstack in a very lightweight matter at the time when we detect the merge conflict, persisting this, and then re-reading this config when the user runs gt continue.

**Changes In This Pull Request:**

This PR persists the interrupted callstack for any method that calls into the fix action.

Test Plan:

yarn build for now, more complex functionality and tests built atop this upstack