### PR TITLE
[Repo Sync] Prune non-existent remote-tracking references

### DIFF
--- a/src/actions/sync.ts
+++ b/src/actions/sync.ts
@@ -39,7 +39,7 @@ export async function syncAction(opts: {
     logNewline();
     logInfo(`Pulling in new changes...`);
     logTip(`Disable this behavior at any point in the future with --no-pull`);
-    gpExecSync({ command: `git pull` }, (err) => {
+    gpExecSync({ command: `git pull --prune` }, (err) => {
       checkoutBranch(oldBranch.name);
       throw new ExitFailedError(`Failed to pull trunk ${trunk}`, err);
     });


### PR DESCRIPTION
**Context:**

A previous feature request.

**Changes In This Pull Request:**

From the git documentation:

-p
--prune
Before fetching, remove any remote-tracking references that no longer exist on the remote. Tags are not subject to pruning if they are fetched only because of the default tag auto-following or due to a --tags option. However, if tags are fetched due to an explicit refspec (either on the command line or in the remote configuration, for example if the remote was cloned with the --mirror option), then they are also subject to pruning. Supplying --prune-tags is a shorthand for providing the tag refspec.

**Test Plan:**

yarn build

