### PR TITLE
 Set editor preference if not set, on submit

### DIFF
--- a/src/actions/submit/pr_body.ts
+++ b/src/actions/submit/pr_body.ts
@@ -4,7 +4,7 @@ import prompts from "prompts";
 import tmp from "tmp";
 import { KilledError } from "../../lib/errors";
 import { getSingleCommitOnBranch } from "../../lib/utils";
-import { getDefaultEditor } from "../../lib/utils/default_editor";
+import { getDefaultEditorOrPrompt } from "../../lib/utils/default_editor";
 import { getPRTemplate } from "../../lib/utils/pr_templates";
 import Branch from "../../wrapper-classes/branch";
 
@@ -18,7 +18,7 @@ export async function getPRBody(args: {
     inferredBodyFromCommit !== null ? inferredBodyFromCommit : template;
   const hasPRTemplate = body !== undefined;
   if (args.editPRFieldsInline) {
-    const defaultEditor = getDefaultEditor();
+    const defaultEditor = await getDefaultEditorOrPrompt();
     const response = await prompts(
       {
         type: "select",

--- a/src/actions/submit/submit.ts
+++ b/src/actions/submit/submit.ts
@@ -31,7 +31,6 @@ import { validate } from "./../validate";
 import { getPRBody } from "./pr_body";
 import { getPRDraftStatus } from "./pr_draft";
 import { getPRTitle } from "./pr_title";
-import { setDefaultEditorPrompt } from "../../lib/utils/default_editor";
 
 type TSubmitScope = TScope | "BRANCH";
 
@@ -87,9 +86,6 @@ export async function submitAction(args: {
   // Force a sync to link any PRs that have remote equivalents, but weren't
   // previously tracked with Graphite.
   await syncPRInfoForBranches(branchesToSubmit);
-
-  // Check to see if default editor is set, if not ask to set it
-  await setDefaultEditorPrompt();
 
   logInfo(
     chalk.blueBright(

--- a/src/actions/submit/submit.ts
+++ b/src/actions/submit/submit.ts
@@ -31,6 +31,7 @@ import { validate } from "./../validate";
 import { getPRBody } from "./pr_body";
 import { getPRDraftStatus } from "./pr_draft";
 import { getPRTitle } from "./pr_title";
+import { setDefaultEditorPrompt } from "../../lib/utils/default_editor";
 
 type TSubmitScope = TScope | "BRANCH";
 
@@ -86,6 +87,9 @@ export async function submitAction(args: {
   // Force a sync to link any PRs that have remote equivalents, but weren't
   // previously tracked with Graphite.
   await syncPRInfoForBranches(branchesToSubmit);
+
+  // Check to see if default editor is set, if not ask to set it
+  await setDefaultEditorPrompt();
 
   logInfo(
     chalk.blueBright(

--- a/src/lib/config/user_config.ts
+++ b/src/lib/config/user_config.ts
@@ -23,6 +23,7 @@ type UserConfigT = {
   branchPrefix?: string;
   authToken?: string;
   tips?: boolean;
+  editor?: string;
 };
 
 class UserConfig {
@@ -56,6 +57,15 @@ class UserConfig {
 
   public toggleTips(enabled: boolean): void {
     this._data.tips = enabled;
+    this.save();
+  }
+
+  public getEditor(): string | undefined {
+    return this._data.editor;
+  }
+
+  public setEditor(editor: string): void {
+    this._data.editor = editor;
     this.save();
   }
 

--- a/src/lib/utils/default_editor.ts
+++ b/src/lib/utils/default_editor.ts
@@ -1,79 +1,77 @@
 import { gpExecSync } from "./exec_sync";
-import {logInfo} from "./splog";
+import { logInfo } from "./splog";
 import chalk from "chalk";
 import prompts from "prompts";
-import {KilledError} from "../errors";
+import { KilledError } from "../errors";
+import { userConfig } from "../../lib/config";
 
+// Find one entry point and set user config editor to the value of GIT_EDITOR or EDITOR if either is set. If neither is set,
+// prompt the user to set it. If they choose to not set it then set it to nano.
 export function getDefaultEditor(): string {
-  const gitEditor = gpExecSync({ command: `echo \${GIT_EDITOR}` })
-    .toString()
-    .trim();
-  if (gitEditor.length !== 0) {
-    return gitEditor;
+  let editor = userConfig.getEditor();
+  if (!editor) {
+    editor = "nano"; //This should prompt instead
   }
-
-  const editor = gpExecSync({ command: `echo \${EDITOR}` }).toString().trim();
-  if (editor.length !== 0) {
-    return editor;
-  }
-
-  return "nano";
-}
-
-export function isDefaultEditorSet(): boolean {
-  let editor = gpExecSync({ command: `echo \${GIT_EDITOR}` })
-      .toString()
-      .trim();
-  if (!editor.length) {
-    editor = gpExecSync({command: `echo \${EDITOR}`}).toString().trim();
-  }
-  return editor.length !== 0;
+  return editor;
 }
 
 export async function setDefaultEditorPrompt(): Promise<void> {
+  if (!userConfig.getEditor()) {
+    // Check if any env variable is set.
+    const systemEditor = gpExecSync({ command: `echo \${GIT_EDITOR:-$EDITOR}` })
+      .toString()
+      .trim();
 
-  if (!isDefaultEditorSet()) {
-    logInfo(
+    let editorPref;
+    if (systemEditor.length) {
+      editorPref = systemEditor;
+    } else {
+      logInfo(
         chalk.yellow(
-            "Your default editor environment variables are not set. Do you wish to set it? (Graphite will use `nano` as default.)"
+          "We did not detect an editor preference in your settings. Do you wish to set it? (Graphite will use `nano` as default.)"
         )
-    );
-  }
-  const yesOrNo = await prompts(
-      {
-        type: "select",
-        name: "editorPrompt",
-        message: "Set default editor now?",
-        choices: [
-          { title: `Yes (will set $EDITOR env variable).`, value: "yes" },
-          {
-            title: `Skip (just use nano as my default editor)`,
-            value: "no", // Should find a way to remember this selection so we are not repeatedly prompting
-          },
-        ],
-      },
-      {
-        onCancel: () => {
-          throw new KilledError();
-        },
-      }
-  );
+      );
 
-  if (yesOrNo.editorPrompt === 'yes') {
-    const editor = await prompts(
+      const yesOrNo = await prompts(
         {
-          type: "text",
-          name: "editor",
-          message: "Enter your choice of editor (eg: vim, nano, emacs etc)", // Should this be a selection?
-          initial: 'nano',
+          type: "select",
+          name: "editorPrompt",
+          message: "Set default editor now?",
+          choices: [
+            { title: `Yes`, value: "yes" },
+            {
+              title: `Skip (just use nano as my default editor)`,
+              value: "no", // Should find a way to remember this selection so we are not repeatedly prompting
+            },
+          ],
         },
         {
           onCancel: () => {
             throw new KilledError();
           },
         }
-    );
+      );
 
-    gpExecSync({command: `export EDITOR=${editor}`}); // Will it require permissions? Will it persist or does it need to be added to .zsh?
+      if (yesOrNo.editorPrompt === "yes") {
+        const response = await prompts(
+          {
+            type: "text",
+            name: "editor",
+            message: "Enter your choice of editor (eg: vim, nano, emacs etc)", // Should this be a selection?
+            initial: "nano",
+          },
+          {
+            onCancel: () => {
+              throw new KilledError();
+            },
+          }
+        );
+        editorPref = response.editor;
+      } else {
+        editorPref = "nano";
+      }
+    }
+
+    userConfig.setEditor(editorPref);
   }
 }

--- a/src/lib/utils/default_editor.ts
+++ b/src/lib/utils/default_editor.ts
@@ -1,4 +1,8 @@
 import { gpExecSync } from "./exec_sync";
+import {logInfo} from "./splog";
+import chalk from "chalk";
+import prompts from "prompts";
+import {KilledError} from "../errors";
 
 export function getDefaultEditor(): string {
   const gitEditor = gpExecSync({ command: `echo \${GIT_EDITOR}` })
@@ -14,4 +18,62 @@ export function getDefaultEditor(): string {
   }
 
   return "nano";
+}
+
+export function isDefaultEditorSet(): boolean {
+  let editor = gpExecSync({ command: `echo \${GIT_EDITOR}` })
+      .toString()
+      .trim();
+  if (!editor.length) {
+    editor = gpExecSync({command: `echo \${EDITOR}`}).toString().trim();
+  }
+  return editor.length !== 0;
+}
+
+export async function setDefaultEditorPrompt(): Promise<void> {
+
+  if (!isDefaultEditorSet()) {
+    logInfo(
+        chalk.yellow(
+            "Your default editor environment variables are not set. Do you wish to set it? (Graphite will use `nano` as default.)"
+        )
+    );
+  }
+  const yesOrNo = await prompts(
+      {
+        type: "select",
+        name: "editorPrompt",
+        message: "Set default editor now?",
+        choices: [
+          { title: `Yes (will set $EDITOR env variable).`, value: "yes" },
+          {
+            title: `Skip (just use nano as my default editor)`,
+            value: "no", // Should find a way to remember this selection so we are not repeatedly prompting
+          },
+        ],
+      },
+      {
+        onCancel: () => {
+          throw new KilledError();
+        },
+      }
+  );
+
+  if (yesOrNo.editorPrompt === 'yes') {
+    const editor = await prompts(
+        {
+          type: "text",
+          name: "editor",
+          message: "Enter your choice of editor (eg: vim, nano, emacs etc)", // Should this be a selection?
+          initial: 'nano',
+        },
+        {
+          onCancel: () => {
+            throw new KilledError();
+          },
+        }
+    );
+
+    gpExecSync({command: `export EDITOR=${editor}`}); // Will it require permissions? Will it persist or does it need to be added to .zsh?
+  }
 }

--- a/src/lib/utils/default_editor.ts
+++ b/src/lib/utils/default_editor.ts
@@ -58,10 +58,14 @@ export async function setDefaultEditorPrompt(): Promise<void> {
       if (yesOrNo.editorPrompt === "yes") {
         const response = await prompts(
           {
-            type: "text",
+            type: "select",
             name: "editor",
             message: "Enter your choice of editor (eg: vim, nano, emacs etc)", // Should this be a selection?
-            initial: "nano",
+            choices: [
+              { title: `vim`, value: "vim" },
+              { title: `emacs`, value: "emacs" },
+              { title: `nano`, value: "nano" },
+            ],
           },
           {
             onCancel: () => {

--- a/src/lib/utils/default_editor.ts
+++ b/src/lib/utils/default_editor.ts
@@ -5,12 +5,15 @@ import prompts from "prompts";
 import { KilledError } from "../errors";
 import { userConfig } from "../../lib/config";
 
-// Find one entry point and set user config editor to the value of GIT_EDITOR or EDITOR if either is set. If neither is set,
-// prompt the user to set it. If they choose to not set it then set it to nano.
+/*
+If the editor is not set, we attempt to infer it from environment variables $GIT_EDITOR or $EDITOR.
+If those are unavailable, we want to prompt user to set them. If user doesn't want to set them, we default to nano.
+ */
+
 export function getDefaultEditor(): string {
   let editor = userConfig.getEditor();
   if (!editor) {
-    editor = "nano"; //This should prompt instead
+    editor = "nano"; //Should this prompt instead?
   }
   return editor;
 }
@@ -73,5 +76,6 @@ export async function setDefaultEditorPrompt(): Promise<void> {
     }
 
     userConfig.setEditor(editorPref);
+    logInfo(`Editor preference set to ${editorPref}.`);
   }
 }

--- a/src/lib/utils/default_editor.ts
+++ b/src/lib/utils/default_editor.ts
@@ -13,13 +13,13 @@ If those are unavailable, we want to prompt user to set them. If user doesn't wa
 export async function getDefaultEditorOrPrompt(): Promise<string>{
   let editor = userConfig.getEditor();
   if (!editor) {
-    await setDefaultEditorPrompt();
+    await setDefaultEditorOrPrompt();
     editor = userConfig.getEditor();
   }
   return editor || 'nano';
 }
 
-export async function setDefaultEditorPrompt(): Promise<void> {
+async function setDefaultEditorOrPrompt(): Promise<void> {
   if (!userConfig.getEditor()) {
     // Check if any env variable is set.
     const systemEditor = gpExecSync({ command: `echo \${GIT_EDITOR:-$EDITOR}` })

--- a/src/lib/utils/default_editor.ts
+++ b/src/lib/utils/default_editor.ts
@@ -11,12 +11,8 @@ If those are unavailable, we want to prompt user to set them. If user doesn't wa
  */
 
 export async function getDefaultEditorOrPrompt(): Promise<string>{
-  let editor = userConfig.getEditor();
-  if (!editor) {
     await setDefaultEditorOrPrompt();
-    editor = userConfig.getEditor();
-  }
-  return editor || 'nano';
+    return userConfig.getEditor() || 'nano';
 }
 
 async function setDefaultEditorOrPrompt(): Promise<void> {
@@ -81,6 +77,6 @@ async function setDefaultEditorOrPrompt(): Promise<void> {
     }
 
     userConfig.setEditor(editorPref);
-    logInfo(`Editor preference set to ${editorPref}.`);
+    logInfo(`Graphite editor preference set to ${editorPref}.`);
   }
 }

--- a/src/lib/utils/default_editor.ts
+++ b/src/lib/utils/default_editor.ts
@@ -10,7 +10,7 @@ If the editor is not set, we attempt to infer it from environment variables $GIT
 If those are unavailable, we want to prompt user to set them. If user doesn't want to set them, we default to nano.
  */
 
-export async function getDefaultEditorOrPrompt(): Promise<string> {
+export async function getDefaultEditorOrPrompt(): Promise<string>{
   let editor = userConfig.getEditor();
   if (!editor) {
     await setDefaultEditorPrompt();

--- a/src/lib/utils/default_editor.ts
+++ b/src/lib/utils/default_editor.ts
@@ -10,12 +10,13 @@ If the editor is not set, we attempt to infer it from environment variables $GIT
 If those are unavailable, we want to prompt user to set them. If user doesn't want to set them, we default to nano.
  */
 
-export function getDefaultEditor(): string {
+export async function getDefaultEditorOrPrompt(): Promise<string> {
   let editor = userConfig.getEditor();
   if (!editor) {
-    editor = "nano"; //Should this prompt instead?
+    await setDefaultEditorPrompt();
+    editor = userConfig.getEditor();
   }
-  return editor;
+  return editor || 'nano';
 }
 
 export async function setDefaultEditorPrompt(): Promise<void> {
@@ -43,7 +44,7 @@ export async function setDefaultEditorPrompt(): Promise<void> {
           choices: [
             { title: `Yes`, value: "yes" },
             {
-              title: `Skip (just use nano as my default editor)`,
+              title: `Skip and use Graphite default (nano)`,
               value: "no", // Should find a way to remember this selection so we are not repeatedly prompting
             },
           ],
@@ -60,7 +61,7 @@ export async function setDefaultEditorPrompt(): Promise<void> {
           {
             type: "select",
             name: "editor",
-            message: "Enter your choice of editor (eg: vim, nano, emacs etc)", // Should this be a selection?
+            message: "Select an editor:", // Should this be a selection?
             choices: [
               { title: `vim`, value: "vim" },
               { title: `emacs`, value: "emacs" },


### PR DESCRIPTION
**Context:**
Currently, the way we choose editor preference is pretty opaque. Prompt the user to set the editor preference if not set on submit. If the user chooses to not set it, then nano is saved as the preference and user will not be prompted again.


**Changes In This Pull Request:**
1. Save editor preference in user config.
2. Prompt user to set the preference (if unset) on submit.
3. Default to nano.

<img width="969" alt="Screen Shot 2021-12-01 at 5 19 30 PM" src="https://user-images.githubusercontent.com/6138253/144323401-200500f3-ffa0-4685-bed8-13ce7cf9a38e.png">

**Test Plan:**
Tested manually.

