### PR TITLE
Allow `gt user editor` to set/unset editor pref

### DIFF
--- a/src/commands/user-commands/editor.ts
+++ b/src/commands/user-commands/editor.ts
@@ -6,13 +6,13 @@ import { logInfo } from "../../lib/utils";
 const args = {
     set: {
         demandOption: false,
-        default: 'nano',
+        default: '',
         type: "string",
         describe: "Set default editor for Graphite",
     },
     unset: {
         demandOption: false,
-        default: true,
+        default: false,
         type: "boolean",
         describe: "Unset default editor for Graphite",
     },

--- a/src/commands/user-commands/editor.ts
+++ b/src/commands/user-commands/editor.ts
@@ -1,0 +1,39 @@
+import yargs from "yargs";
+import { userConfig } from "../../lib/config";
+import { profile } from "../../lib/telemetry";
+import { logInfo } from "../../lib/utils";
+
+const args = {
+    set: {
+        demandOption: false,
+        default: 'nano',
+        type: "string",
+        describe: "Set default editor for Graphite",
+    },
+    unset: {
+        demandOption: false,
+        default: true,
+        type: "boolean",
+        describe: "Unset default editor for Graphite",
+    },
+} as const;
+
+type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
+
+export const command = "editor";
+export const description = "Editor used when using Graphite";
+export const canonical = "user editor";
+export const builder = args;
+export const handler = async (argv: argsT): Promise<void> => {
+    return profile(argv, canonical, async () => {
+        if (argv.set) {
+            userConfig.setEditor(argv.set);
+            logInfo(`Editor preference set to: ${argv.set}`);
+        } else if (argv.unset) {
+            userConfig.setEditor('nano')
+            logInfo(`Editor preference erased. Defaulting to Graphite default: nano`);
+        } else {
+            logInfo(`Current editor preference is set to : ${userConfig.getEditor()}`)
+        }
+    });
+};

--- a/src/commands/user-commands/editor.ts
+++ b/src/commands/user-commands/editor.ts
@@ -19,7 +19,7 @@ const args = {
 } as const;
 
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
-
+export const DEFAULT_GRAPHITE_EDITOR = 'nano';
 export const command = "editor";
 export const description = "Editor used when using Graphite";
 export const canonical = "user editor";
@@ -30,8 +30,8 @@ export const handler = async (argv: argsT): Promise<void> => {
             userConfig.setEditor(argv.set);
             logInfo(`Editor preference set to: ${argv.set}`);
         } else if (argv.unset) {
-            userConfig.setEditor('nano')
-            logInfo(`Editor preference erased. Defaulting to Graphite default: nano`);
+            userConfig.setEditor(DEFAULT_GRAPHITE_EDITOR);
+            logInfo(`Editor preference erased. Defaulting to Graphite default: ${DEFAULT_GRAPHITE_EDITOR}`);
         } else {
             logInfo(`Current editor preference is set to : ${userConfig.getEditor()}`)
         }

--- a/src/lib/utils/default_editor.ts
+++ b/src/lib/utils/default_editor.ts
@@ -1,5 +1,5 @@
 import { gpExecSync } from "./exec_sync";
-import { logInfo } from "./splog";
+import {logInfo, logTip} from "./splog";
 import chalk from "chalk";
 import prompts from "prompts";
 import { KilledError } from "../errors";
@@ -25,6 +25,9 @@ async function setDefaultEditorOrPrompt(): Promise<void> {
     let editorPref;
     if (systemEditor.length) {
       editorPref = systemEditor;
+      logTip(`Graphite will now use ${editorPref} as the default editor setting. 
+      We infer it from your environment variables ($GIT_EDITOR || $EDITOR). 
+      If you wish to change it, use \`gt user editor\` to change this in the future`);
     } else {
       logInfo(
         chalk.yellow(
@@ -77,6 +80,6 @@ async function setDefaultEditorOrPrompt(): Promise<void> {
     }
 
     userConfig.setEditor(editorPref);
-    logInfo(`Graphite editor preference set to ${editorPref}.`);
+    logInfo( chalk.yellow(`Graphite editor preference set to ${editorPref}.`));
   }
 }

--- a/src/lib/utils/default_editor.ts
+++ b/src/lib/utils/default_editor.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import prompts from "prompts";
 import { KilledError } from "../errors";
 import { userConfig } from "../../lib/config";
+import { DEFAULT_GRAPHITE_EDITOR } from "../../commands/user-commands/editor";
 
 /*
 If the editor is not set, we attempt to infer it from environment variables $GIT_EDITOR or $EDITOR.
@@ -12,7 +13,7 @@ If those are unavailable, we want to prompt user to set them. If user doesn't wa
 
 export async function getDefaultEditorOrPrompt(): Promise<string>{
     await setDefaultEditorOrPrompt();
-    return userConfig.getEditor() || 'nano';
+    return userConfig.getEditor() || DEFAULT_GRAPHITE_EDITOR;
 }
 
 async function setDefaultEditorOrPrompt(): Promise<void> {
@@ -31,7 +32,7 @@ async function setDefaultEditorOrPrompt(): Promise<void> {
     } else {
       logInfo(
         chalk.yellow(
-          "We did not detect an editor preference in your settings. Do you wish to set it? (Graphite will use `nano` as default.)"
+          `We did not detect an editor preference in your settings. Do you wish to set it? (Graphite will use ${DEFAULT_GRAPHITE_EDITOR} as default.)`
         )
       );
 
@@ -43,7 +44,7 @@ async function setDefaultEditorOrPrompt(): Promise<void> {
           choices: [
             { title: `Yes`, value: "yes" },
             {
-              title: `Skip and use Graphite default (nano)`,
+              title: `Skip and use Graphite default (${DEFAULT_GRAPHITE_EDITOR})`,
               value: "no", // Should find a way to remember this selection so we are not repeatedly prompting
             },
           ],
@@ -75,7 +76,7 @@ async function setDefaultEditorOrPrompt(): Promise<void> {
         );
         editorPref = response.editor;
       } else {
-        editorPref = "nano";
+        editorPref = DEFAULT_GRAPHITE_EDITOR;
       }
     }
 

--- a/test/fast/commands/user_config/editor.test.ts
+++ b/test/fast/commands/user_config/editor.test.ts
@@ -1,0 +1,54 @@
+import { expect } from "chai";
+import { userConfig } from "../../../../src/lib/config";
+import { BasicScene } from "../../../lib/scenes";
+import { configureTest } from "../../../lib/utils";
+
+for (const scene of [new BasicScene()]) {
+    describe(`(${scene}): auth`, function () {
+        configureTest(this, scene);
+
+        /**
+         * If users run this test locally, we don't want it to mangle their editor settings
+         * As a result, before we run our tests, we save their editor preference
+         * and after finishing our tests, we reset their editor preference.
+         */
+        let editorPref: string | undefined;
+        before(function () {
+            editorPref = userConfig.getEditor();
+        });
+
+        it("Sanity check - can check editor", () => {
+            scene.repo.execCliCommand(`user editor --unset`);
+            expect(() =>
+                scene.repo.execCliCommand(`user editor`)
+            ).to.not.throw(Error);
+            expect(scene.repo.execCliCommandAndGetOutput(`user editor`))
+                .to
+                .equal('Current editor preference is set to : nano');
+        });
+
+        it("Sanity check - can set editor", () => {
+            expect(() =>
+                scene.repo.execCliCommand(`user editor --set vim`)
+            ).to.not.throw(Error);
+            expect(scene.repo.execCliCommandAndGetOutput(`user editor`))
+                .to
+                .equal('Current editor preference is set to : vim');
+        });
+
+        it("Sanity check - can unset editor", () => {
+            expect(() =>
+                scene.repo.execCliCommand(`user editor --unset`)
+            ).to.not.throw(Error);
+            expect(scene.repo.execCliCommandAndGetOutput(`user editor`))
+                .to
+                .equal('Current editor preference is set to : nano');
+        });
+
+        after(function () {
+            if (editorPref !== undefined) {
+                userConfig.setEditor(editorPref);
+            }
+        });
+    });
+}

--- a/test/fast/commands/user_config/editor.test.ts
+++ b/test/fast/commands/user_config/editor.test.ts
@@ -3,6 +3,7 @@ import { userConfig } from "../../../../src/lib/config";
 import { BasicScene } from "../../../lib/scenes";
 import { configureTest } from "../../../lib/utils";
 import { logInfo } from "../../../../src/lib/utils";
+import { DEFAULT_GRAPHITE_EDITOR } from "../../../../src/commands/user-commands/editor";
 
 for (const scene of [new BasicScene()]) {
     describe(`(${scene}): user editor`, function () {
@@ -37,10 +38,10 @@ for (const scene of [new BasicScene()]) {
         });
 
         it("Sanity check - can unset editor", () => {
-            expect(scene.repo.execCliCommandAndGetOutput(`user editor --unset`)).to.equal('Editor preference erased. Defaulting to Graphite default: nano')
+            expect(scene.repo.execCliCommandAndGetOutput(`user editor --unset`)).to.equal(`Editor preference erased. Defaulting to Graphite default: ${DEFAULT_GRAPHITE_EDITOR}`)
             expect(scene.repo.execCliCommandAndGetOutput(`user editor`))
                 .to
-                .equal('Current editor preference is set to : nano');
+                .equal(`Current editor preference is set to : ${DEFAULT_GRAPHITE_EDITOR}`);
         });
 
         after(function () {

--- a/test/fast/commands/user_config/editor.test.ts
+++ b/test/fast/commands/user_config/editor.test.ts
@@ -2,9 +2,10 @@ import { expect } from "chai";
 import { userConfig } from "../../../../src/lib/config";
 import { BasicScene } from "../../../lib/scenes";
 import { configureTest } from "../../../lib/utils";
+import { logInfo } from "../../../../src/lib/utils";
 
 for (const scene of [new BasicScene()]) {
-    describe(`(${scene}): auth`, function () {
+    describe(`(${scene}): user editor`, function () {
         configureTest(this, scene);
 
         /**
@@ -15,6 +16,7 @@ for (const scene of [new BasicScene()]) {
         let editorPref: string | undefined;
         before(function () {
             editorPref = userConfig.getEditor();
+            logInfo(`Existing user pref: ${editorPref}`);
         });
 
         it("Sanity check - can check editor", () => {
@@ -28,18 +30,14 @@ for (const scene of [new BasicScene()]) {
         });
 
         it("Sanity check - can set editor", () => {
-            expect(() =>
-                scene.repo.execCliCommand(`user editor --set vim`)
-            ).to.not.throw(Error);
+            expect(scene.repo.execCliCommandAndGetOutput(`user editor --set vim`)).to.equal('Editor preference set to: vim')
             expect(scene.repo.execCliCommandAndGetOutput(`user editor`))
                 .to
                 .equal('Current editor preference is set to : vim');
         });
 
         it("Sanity check - can unset editor", () => {
-            expect(() =>
-                scene.repo.execCliCommand(`user editor --unset`)
-            ).to.not.throw(Error);
+            expect(scene.repo.execCliCommandAndGetOutput(`user editor --unset`)).to.equal('Editor preference erased. Defaulting to Graphite default: nano')
             expect(scene.repo.execCliCommandAndGetOutput(`user editor`))
                 .to
                 .equal('Current editor preference is set to : nano');
@@ -48,6 +46,7 @@ for (const scene of [new BasicScene()]) {
         after(function () {
             if (editorPref !== undefined) {
                 userConfig.setEditor(editorPref);
+                logInfo(`Reset user pref: ${editorPref}`);
             }
         });
     });


### PR DESCRIPTION
**Context:**
Since we are now saving editor preferences in user config, allow `gt user editor` to change them.


**Changes In This Pull Request:**


<img width="424" alt="Screen Shot 2021-12-01 at 6 02 27 PM" src="https://user-images.githubusercontent.com/6138253/144328245-025e69e5-804d-4347-b805-951b0df5e2e4.png">

**Test Plan:**
Tested manually.

