### PR TITLE
fix(feedback): allow sending debug-context, disable help for now

### DIFF
--- a/src/commands/feedback-commands/default.ts
+++ b/src/commands/feedback-commands/default.ts
@@ -1,11 +1,11 @@
-import graphiteCLIRoutes from "@screenplaydev/graphite-cli-routes";
-import { request } from "@screenplaydev/retyped-routes";
-import chalk from "chalk";
-import yargs from "yargs";
-import { API_SERVER } from "../../lib/api";
-import { captureState } from "../../lib/debug-context";
-import { ExitFailedError } from "../../lib/errors";
-import { getUserEmail, profile } from "../../lib/telemetry";
+import graphiteCLIRoutes from '@screenplaydev/graphite-cli-routes';
+import { request } from '@screenplaydev/retyped-routes';
+import chalk from 'chalk';
+import yargs from 'yargs';
+import { API_SERVER } from '../../lib/api';
+import { captureState } from '../../lib/debug-context';
+import { ExitFailedError } from '../../lib/errors';
+import { getUserEmail, profile } from '../../lib/telemetry';
 
 const args = {
   message: {

--- a/src/commands/feedback-commands/default.ts
+++ b/src/commands/feedback-commands/default.ts
@@ -26,7 +26,6 @@ type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
 export const command = '* <message>';
 export const canonical = 'feedback';
-export const showHelpOnFail = true;
 export const description =
   "Post a string directly to the maintainers' Slack where they can factor in your feedback, laugh at your jokes, cry at your insults, or test the bounds of Slack injection attacks.";
 export const builder = args;

--- a/src/commands/feedback-commands/default.ts
+++ b/src/commands/feedback-commands/default.ts
@@ -33,27 +33,28 @@ export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, canonical, async () => {
     const user = getUserEmail();
-    if (argv.message) {
-      const response = await request.requestWithArgs(
-        API_SERVER,
-        graphiteCLIRoutes.feedback,
-        {
-          user: user || 'NotFound',
-          message: argv.message,
-          debugContext: argv.debugContext ? captureState() : undefined,
-        }
-      );
-      if (response._response.status == 200) {
-        console.log(
-          chalk.green(
-            `Feedback received loud and clear (in a team Slack channel) :)`
-          )
-        );
-      } else {
-        throw new ExitFailedError(
-          `Failed to report feedback, network response ${response.status}`
-        );
+    if (!argv.message) {
+      return;
+    }
+    const response = await request.requestWithArgs(
+      API_SERVER,
+      graphiteCLIRoutes.feedback,
+      {
+        user: user || 'NotFound',
+        message: argv.message,
+        debugContext: argv.debugContext ? captureState() : undefined,
       }
+    );
+    if (response._response.status == 200) {
+      console.log(
+        chalk.green(
+          `Feedback received loud and clear (in a team Slack channel) :)`
+        )
+      );
+    } else {
+      throw new ExitFailedError(
+        `Failed to report feedback, network response ${response.status}`
+      );
     }
   });
 };

--- a/src/commands/feedback-commands/default.ts
+++ b/src/commands/feedback-commands/default.ts
@@ -17,9 +17,10 @@ const args = {
   },
   debugContext: {
     type: 'boolean',
+    alias: ['with-debug-context'],
     default: false,
     describe:
-      "Include a blob of json descripting your repo's state to help with debugging. Run 'gt feedback state' to see what would be included.",
+      "Include a blob of json describing your repo's state to help with debugging. Run 'gt feedback debug-context' to see what would be included.",
   },
 } as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;

--- a/src/commands/feedback-commands/default.ts
+++ b/src/commands/feedback-commands/default.ts
@@ -33,25 +33,27 @@ export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, canonical, async () => {
     const user = getUserEmail();
-    const response = await request.requestWithArgs(
-      API_SERVER,
-      graphiteCLIRoutes.feedback,
-      {
-        user: user || 'NotFound',
-        message: argv.message,
-        debugContext: argv.debugContext ? captureState() : undefined,
+    if (argv.message) {
+      const response = await request.requestWithArgs(
+        API_SERVER,
+        graphiteCLIRoutes.feedback,
+        {
+          user: user || 'NotFound',
+          message: argv.message,
+          debugContext: argv.debugContext ? captureState() : undefined,
+        }
+      );
+      if (response._response.status == 200) {
+        console.log(
+          chalk.green(
+            `Feedback received loud and clear (in a team Slack channel) :)`
+          )
+        );
+      } else {
+        throw new ExitFailedError(
+          `Failed to report feedback, network response ${response.status}`
+        );
       }
-    );
-    if (response._response.status == 200) {
-      console.log(
-        chalk.green(
-          `Feedback received loud and clear (in a team Slack channel) :)`
-        )
-      );
-    } else {
-      throw new ExitFailedError(
-        `Failed to report feedback, network response ${response.status}`
-      );
     }
   });
 };

--- a/src/commands/feedback-commands/default.ts
+++ b/src/commands/feedback-commands/default.ts
@@ -15,9 +15,8 @@ const args = {
     describe:
       'Positive or constructive feedback for the Graphite team! Jokes are chill too.',
   },
-  debugContext: {
+  'with-debug-context': {
     type: 'boolean',
-    alias: ['with-debug-context'],
     default: false,
     describe:
       "Include a blob of json describing your repo's state to help with debugging. Run 'gt feedback debug-context' to see what would be included.",
@@ -43,7 +42,7 @@ export const handler = async (argv: argsT): Promise<void> => {
       {
         user: user || 'NotFound',
         message: argv.message,
-        debugContext: argv.debugContext ? captureState() : undefined,
+        debugContext: argv['with-debug-context'] ? captureState() : undefined,
       }
     );
     if (response._response.status == 200) {

--- a/src/commands/feedback-commands/default.ts
+++ b/src/commands/feedback-commands/default.ts
@@ -1,20 +1,21 @@
-import graphiteCLIRoutes from '@screenplaydev/graphite-cli-routes';
-import { request } from '@screenplaydev/retyped-routes';
-import chalk from 'chalk';
-import yargs from 'yargs';
-import { API_SERVER } from '../../lib/api';
-import { captureState } from '../../lib/debug-context';
-import { ExitFailedError } from '../../lib/errors';
-import { getUserEmail, profile } from '../../lib/telemetry';
+import graphiteCLIRoutes from "@screenplaydev/graphite-cli-routes";
+import { request } from "@screenplaydev/retyped-routes";
+import chalk from "chalk";
+import yargs from "yargs";
+import { API_SERVER } from "../../lib/api";
+import { captureState } from "../../lib/debug-context";
+import { ExitFailedError } from "../../lib/errors";
+import { getUserEmail, profile } from "../../lib/telemetry";
 
 const args = {
   message: {
     type: 'string',
-    postitional: true,
+    positional: true,
+    demandOption: true,
     describe:
-      'Postive or constructive feedback for the Graphite team! Jokes are chill too.',
+      'Positive or constructive feedback for the Graphite team! Jokes are chill too.',
   },
-  'with-debug-context': {
+  debugContext: {
     type: 'boolean',
     default: false,
     describe:
@@ -25,6 +26,7 @@ type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
 export const command = '* <message>';
 export const canonical = 'feedback';
+export const showHelpOnFail = true;
 export const description =
   "Post a string directly to the maintainers' Slack where they can factor in your feedback, laugh at your jokes, cry at your insults, or test the bounds of Slack injection attacks.";
 export const builder = args;
@@ -37,8 +39,8 @@ export const handler = async (argv: argsT): Promise<void> => {
       graphiteCLIRoutes.feedback,
       {
         user: user || 'NotFound',
-        message: argv.message || '',
-        debugContext: argv['with-debug-context'] ? captureState() : undefined,
+        message: argv.message,
+        debugContext: argv.debugContext ? captureState() : undefined,
       }
     );
     if (response._response.status == 200) {

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -8,5 +8,6 @@ export const builder = function (yargs: yargs.Argv): yargs.Argv {
       extensions: ['js'],
     })
     .strict()
+    .showHelpOnFail(false)
     .demandCommand();
 };

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+import { logInfo } from '../lib/utils';
 
 export const command = 'feedback <command>';
 export const desc = 'Commands for providing feedback and debug state.';
@@ -9,5 +10,8 @@ export const builder = function (yargs: yargs.Argv): yargs.Argv {
     })
     .strict()
     .showHelpOnFail(false)
+    .fail(function (msg) {
+      logInfo(`${msg} Use 'gt feedback --help' for usage instructions`);
+    })
     .demandCommand();
 };

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -1,5 +1,4 @@
 import yargs from 'yargs';
-import { logInfo } from '../lib/utils';
 
 export const command = 'feedback <command>';
 export const desc = 'Commands for providing feedback and debug state.';
@@ -9,9 +8,6 @@ export const builder = function (yargs: yargs.Argv): yargs.Argv {
       extensions: ['js'],
     })
     .strict()
-    .showHelpOnFail(false)
-    .fail(function (msg) {
-      logInfo(`${msg} Use 'gt feedback --help' for usage instructions`);
-    })
+    .showHelpOnFail(false, `Use 'gt feedback --help' for usage`)
     .demandCommand();
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,6 +905,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "ansi-regex@npm:5.0.1"
+  checksum: c944e1229f022a2071f7477ea425964328c577d2c752083fe564ea0513b6d733c9ec65102f6d4d2b54cba0cb2dc969648b60d567abeff13dc95ecc0b9b97737d
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
@@ -4196,6 +4203,17 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
+"string-width@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
+  dependencies:
+    emoji-regex: ^8.0.0
+    is-fullwidth-code-point: ^3.0.0
+    strip-ansi: ^6.0.1
+  checksum: 748c97988904505fc6af52ccdf6f354445c714c38d067f22e0cdc6a3ad3d9c5ea29582ef9a6277dc7a813775bb48390ea064b488913239d58601b6d1fcb725b4
+  languageName: node
+  linkType: hard
+
 "string_decoder@npm:^1.1.1":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
@@ -4238,6 +4256,15 @@ fsevents@~2.3.1:
   dependencies:
     ansi-regex: ^5.0.0
   checksum: 10568c91cadbef182a807c38dfa718dce15a35b12fcc97b96b6b2029d0508ef66ca93fabddeb49482d9b027495d1e18591858e80f27ad26861c4967c60fd207f
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "strip-ansi@npm:6.0.1"
+  dependencies:
+    ansi-regex: ^5.0.1
+  checksum: 9d3061240b03abe5beaf403893464fdc924f43664debe822d5e9146b56c1398b88003f8afdb97eb0cea955c568f6bbfa4923d2b2a08a3a079fd09ee3b5402efb
   languageName: node
   linkType: hard
 
@@ -4657,6 +4684,13 @@ typescript@^4.2.4:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^21.0.0":
+  version: 21.0.0
+  resolution: "yargs-parser@npm:21.0.0"
+  checksum: d5480559eeacbcba477d0344d0e207df402b39e8adc6c2c32b15ee455320655b9c6263435bc707d7f9642d0415c2277ca756ce17e21c4564caa28e954d7d0678
+  languageName: node
+  linkType: hard
+
 "yargs-unparser@npm:2.0.0":
   version: 2.0.0
   resolution: "yargs-unparser@npm:2.0.0"
@@ -4684,7 +4718,7 @@ typescript@^4.2.4:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.0.0, yargs@npm:^17.0.1":
+"yargs@npm:^17.0.0":
   version: 17.0.1
   resolution: "yargs@npm:17.0.1"
   dependencies:
@@ -4696,6 +4730,21 @@ typescript@^4.2.4:
     y18n: ^5.0.5
     yargs-parser: ^20.2.2
   checksum: a7969b48d2dea129a7d4fcc3f13e88d4f94bacbd24f720b2ce19946fa9facc42cfed89c059d953091241f4e9e9000ed9dbf86e4bb4b6ceb3a26af10ddebdd0b2
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.0.1":
+  version: 17.3.0
+  resolution: "yargs@npm:17.3.0"
+  dependencies:
+    cliui: ^7.0.2
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.3
+    y18n: ^5.0.5
+    yargs-parser: ^21.0.0
+  checksum: 065360abd705d4a3af56db585ba9d3b0c47876ccbc1dbf471cfe6bbcf3ef0008968856447a9eb45dfef95dc7e3a04b315f7f79d25df567032015cb213ef235d4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,13 +905,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "ansi-regex@npm:5.0.1"
-  checksum: c944e1229f022a2071f7477ea425964328c577d2c752083fe564ea0513b6d733c9ec65102f6d4d2b54cba0cb2dc969648b60d567abeff13dc95ecc0b9b97737d
-  languageName: node
-  linkType: hard
-
 "ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
@@ -4203,17 +4196,6 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"string-width@npm:^4.2.3":
-  version: 4.2.3
-  resolution: "string-width@npm:4.2.3"
-  dependencies:
-    emoji-regex: ^8.0.0
-    is-fullwidth-code-point: ^3.0.0
-    strip-ansi: ^6.0.1
-  checksum: 748c97988904505fc6af52ccdf6f354445c714c38d067f22e0cdc6a3ad3d9c5ea29582ef9a6277dc7a813775bb48390ea064b488913239d58601b6d1fcb725b4
-  languageName: node
-  linkType: hard
-
 "string_decoder@npm:^1.1.1":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
@@ -4256,15 +4238,6 @@ fsevents@~2.3.1:
   dependencies:
     ansi-regex: ^5.0.0
   checksum: 10568c91cadbef182a807c38dfa718dce15a35b12fcc97b96b6b2029d0508ef66ca93fabddeb49482d9b027495d1e18591858e80f27ad26861c4967c60fd207f
-  languageName: node
-  linkType: hard
-
-"strip-ansi@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "strip-ansi@npm:6.0.1"
-  dependencies:
-    ansi-regex: ^5.0.1
-  checksum: 9d3061240b03abe5beaf403893464fdc924f43664debe822d5e9146b56c1398b88003f8afdb97eb0cea955c568f6bbfa4923d2b2a08a3a079fd09ee3b5402efb
   languageName: node
   linkType: hard
 
@@ -4684,13 +4657,6 @@ typescript@^4.2.4:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^21.0.0":
-  version: 21.0.0
-  resolution: "yargs-parser@npm:21.0.0"
-  checksum: d5480559eeacbcba477d0344d0e207df402b39e8adc6c2c32b15ee455320655b9c6263435bc707d7f9642d0415c2277ca756ce17e21c4564caa28e954d7d0678
-  languageName: node
-  linkType: hard
-
 "yargs-unparser@npm:2.0.0":
   version: 2.0.0
   resolution: "yargs-unparser@npm:2.0.0"
@@ -4718,7 +4684,7 @@ typescript@^4.2.4:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.0.0":
+"yargs@npm:^17.0.0, yargs@npm:^17.0.1":
   version: 17.0.1
   resolution: "yargs@npm:17.0.1"
   dependencies:
@@ -4730,21 +4696,6 @@ typescript@^4.2.4:
     y18n: ^5.0.5
     yargs-parser: ^20.2.2
   checksum: a7969b48d2dea129a7d4fcc3f13e88d4f94bacbd24f720b2ce19946fa9facc42cfed89c059d953091241f4e9e9000ed9dbf86e4bb4b6ceb3a26af10ddebdd0b2
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^17.0.1":
-  version: 17.3.0
-  resolution: "yargs@npm:17.3.0"
-  dependencies:
-    cliui: ^7.0.2
-    escalade: ^3.1.1
-    get-caller-file: ^2.0.5
-    require-directory: ^2.1.1
-    string-width: ^4.2.3
-    y18n: ^5.0.5
-    yargs-parser: ^21.0.0
-  checksum: 065360abd705d4a3af56db585ba9d3b0c47876ccbc1dbf471cfe6bbcf3ef0008968856447a9eb45dfef95dc7e3a04b315f7f79d25df567032015cb213ef235d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Changes In This Pull Request:**
- Allow the --debugContext to submit debug context automatically to slack
- Disable help on failure because for some reason help is not being read correctly.


**Context:**
`gt feedback` on failure displays incorrect help menu. 


**Test Plan:**
Tested manually

