### PR TITLE
Fix git log for cases where branch name matches an existing file

### DIFF
--- a/src/lib/utils/committer_date.ts
+++ b/src/lib/utils/committer_date.ts
@@ -19,7 +19,7 @@ export function getCommitterDate(args: {
 
   return gpExecSync(
     {
-      command: `git log -1 --format=${logFormat} -n 1 ${args.revision}`,
+      command: `git log -1 --format=${logFormat} -n 1 ${args.revision} --`,
     },
     (err) => {
       throw new ExitFailedError(

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -252,7 +252,7 @@ export default class Branch {
 
   public lastCommitTime(): number {
     return parseInt(
-      gpExecSync({ command: `git log ${this.name} -1 --format=%ct` })
+      gpExecSync({ command: `git log -1 --format=%ct ${this.name} --` })
         .toString()
         .trim()
     );

--- a/src/wrapper-classes/commit.ts
+++ b/src/wrapper-classes/commit.ts
@@ -28,7 +28,7 @@ export default class Commit {
   private messageImpl(format: "B" | "b" | "s"): string {
     const message = gpExecSync(
       {
-        command: `git log --format=%${format} -n 1 ${this.sha}`,
+        command: `git log --format=%${format} -n 1 ${this.sha} --`,
       },
       (_) => {
         // just soft-fail if we can't find the commits

--- a/test/fast/commands/log/short.test.ts
+++ b/test/fast/commands/log/short.test.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { execSync } from "child_process";
 import { TrailingProdScene } from "../../../lib/scenes";
 import { configureTest } from "../../../lib/utils";
+import fs from "fs-extra";
 
 for (const scene of [new TrailingProdScene()]) {
   describe(`(${scene}): log short`, function () {
@@ -32,6 +33,21 @@ for (const scene of [new TrailingProdScene()]) {
       scene.repo.execCliCommand(`branch create a`);
       scene.repo.checkoutBranch("main");
       expect(() => scene.repo.execCliCommand("log short")).to.throw(Error);
+    });
+
+    it("Works if branch and file have same name", () => {
+      const textFileName = "test.txt"
+      scene.repo.execCliCommand(`branch create ${textFileName}`);
+
+      // Creates a commit with contents "a" in file "test.txt"
+      scene.repo.createChangeAndCommit("a");
+      expect(fs.existsSync(textFileName)).to.be.true;
+
+      scene.repo.checkoutBranch(textFileName)
+
+      // gt log should work - using "test.txt" as a revision rather than a path
+      expect(() => scene.repo.execCliCommand("log")).to.not.throw(Error);
+      expect(() => scene.repo.execCliCommand("log short")).to.not.throw(Error);
     });
   });
 }


### PR DESCRIPTION
**Context:**

git log will crash if there's a branch and a file with the same name


**Changes In This Pull Request:**

Fix all instances of git log


**Test Plan:**

Added a test for the git log used in `gt log`
There's another one used in `gt log short` which I tested manually, but had trouble adding a unit test for - as it only appeared when there were multiple untracked stacks (only used in the sorting of stacks).
