### PR TITLE
Allow gt repo sync with untracked files

### DIFF
--- a/src/actions/commit_amend.ts
+++ b/src/actions/commit_amend.ts
@@ -1,6 +1,6 @@
 import { execStateConfig } from '../lib/config';
 import { ExitFailedError } from '../lib/errors';
-import { uncommittedChangesPrecondition } from '../lib/preconditions';
+import { uncommittedTrackedChangesPrecondition } from '../lib/preconditions';
 import { gpExecSync, logWarn } from '../lib/utils';
 import Branch from '../wrapper-classes/branch';
 import { fixAction } from './fix';
@@ -50,7 +50,7 @@ export async function commitAmendAction(opts: {
   );
   // Only restack if working tree is now clean.
   try {
-    uncommittedChangesPrecondition();
+    uncommittedTrackedChangesPrecondition();
     await fixAction({
       action: 'rebase',
       mergeConflictCallstack: 'TOP_OF_CALLSTACK_WITH_NOTHING_AFTER' as const,

--- a/src/actions/commit_create.ts
+++ b/src/actions/commit_create.ts
@@ -2,7 +2,7 @@ import { execStateConfig } from '../lib/config';
 import { ExitFailedError } from '../lib/errors';
 import {
   ensureSomeStagedChangesPrecondition,
-  uncommittedChangesPrecondition,
+  uncommittedTrackedChangesPrecondition,
 } from '../lib/preconditions';
 import { gpExecSync, logWarn } from '../lib/utils';
 import { fixAction } from './fix';
@@ -55,7 +55,7 @@ export async function commitCreateAction(opts: {
   }
 
   try {
-    uncommittedChangesPrecondition();
+    uncommittedTrackedChangesPrecondition();
     await fixAction({
       action: 'rebase',
       mergeConflictCallstack: 'TOP_OF_CALLSTACK_WITH_NOTHING_AFTER' as const,

--- a/src/actions/fix.ts
+++ b/src/actions/fix.ts
@@ -13,7 +13,7 @@ import {
 } from '../lib/errors';
 import {
   currentBranchPrecondition,
-  uncommittedChangesPrecondition,
+  uncommittedTrackedChangesPrecondition,
 } from '../lib/preconditions';
 import {
   checkoutBranch,
@@ -83,7 +83,7 @@ export async function fixAction(opts: {
   mergeConflictCallstack: MergeConflictCallstackT;
 }): Promise<void> {
   const currentBranch = currentBranchPrecondition();
-  uncommittedChangesPrecondition();
+  uncommittedTrackedChangesPrecondition();
 
   logDebug(`Determining full meta stack from ${currentBranch.name}`);
   const metaStack = new MetaStackBuilder({

--- a/src/actions/onto.ts
+++ b/src/actions/onto.ts
@@ -21,7 +21,7 @@ import {
   gpExecSync,
   logInfo,
   rebaseInProgress,
-  uncommittedChanges,
+  trackedUncommittedChanges,
 } from '../lib/utils';
 import Branch from '../wrapper-classes/branch';
 import { restackBranch } from './fix';
@@ -29,7 +29,7 @@ export async function ontoAction(args: {
   onto: string;
   mergeConflictCallstack: MergeConflictCallstackT;
 }): Promise<void> {
-  if (uncommittedChanges()) {
+  if (trackedUncommittedChanges()) {
     throw new PreconditionsFailedError('Cannot fix with uncommitted changes');
   }
 

--- a/src/actions/sync.ts
+++ b/src/actions/sync.ts
@@ -10,7 +10,7 @@ import {
   logInfo,
   logNewline,
   logTip,
-  uncommittedChanges,
+  trackedUncommittedChanges,
 } from '../lib/utils';
 import Branch from '../wrapper-classes/branch';
 import { deleteMergedBranches } from './clean_branches';
@@ -25,7 +25,7 @@ export async function syncAction(opts: {
   resubmit: boolean;
   fixDanglingBranches: boolean;
 }): Promise<void> {
-  if (uncommittedChanges()) {
+  if (trackedUncommittedChanges()) {
     throw new PreconditionsFailedError('Cannot sync with uncommitted changes');
   }
   const oldBranch = currentBranchPrecondition();

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -4,7 +4,7 @@ import { detectStagedChanges } from './detect_staged_changes';
 import { detectUnsubmittedChanges } from './detect_unsubmitted_changes';
 import { gpExecSync } from './exec_sync';
 import GitRepo from './git_repo';
-import { uncommittedChanges, unstagedChanges } from './git_status_utils';
+import { trackedUncommittedChanges, uncommittedChanges, unstagedChanges } from './git_status_utils';
 import { makeId } from './make_id';
 import { parseArgs } from './parse_args';
 import { preprocessCommand } from './preprocess_command';
@@ -38,6 +38,7 @@ export {
   detectStagedChanges,
   detectUnsubmittedChanges,
   uncommittedChanges,
+  trackedUncommittedChanges,
   unstagedChanges,
   getTrunk,
   GitRepo,


### PR DESCRIPTION
**Context:**
When editing gitignore on one branch, you end up with untracked files on other simultaneous branches.
Git itself lets you do checkouts with existing untracked files unless they would be clobbered by checkout. Allow this to work the same way.


**Changes In This Pull Request:**



**Test Plan:**
Confirmed manually that `git status -uno` does what we want - so use that helper instead.