### PR TITLE
feat: dev command to create test stack

### DIFF
--- a/src/commands/dev-commands/stack.ts
+++ b/src/commands/dev-commands/stack.ts
@@ -1,0 +1,46 @@
+import { execSync } from 'child_process';
+import yargs from 'yargs';
+import { currentGitRepoPrecondition } from '../../lib/preconditions';
+import { profile } from '../../lib/telemetry';
+import { GitRepo, makeId } from '../../lib/utils';
+
+export const command = 'create-stack';
+export const canonical = 'create-stack';
+export const aliases = ['cs'];
+export const description = false;
+
+const args = {} as const;
+export const builder = args;
+
+type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
+export const handler = async (argv: argsT): Promise<void> => {
+  return profile(argv, canonical, async () => {
+    const repoPath = currentGitRepoPrecondition();
+    const repo = new GitRepo(repoPath, {
+      existingRepo: true,
+    });
+
+    const id = makeId(4);
+
+    repo.createChange('[1/3] Add review queue filter api');
+    execCliCommand(
+      `branch create '${id}--a' -m '[Product] Add review queue filter api'`
+    );
+
+    repo.createChange('[2/3] Add review queue filter server');
+    execCliCommand(
+      `branch create '${id}--b' -m '[Product] Add review queue filter server'`
+    );
+
+    repo.createChange('[3/3] Add review queue filter frontend');
+    execCliCommand(
+      `branch create '${id}--c' -m '[Product] Add review queue filter frontend'`
+    );
+  });
+};
+
+function execCliCommand(command: string) {
+  execSync(`gt ${command}`, {
+    stdio: 'inherit',
+  });
+}

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,0 +1,13 @@
+import yargs from 'yargs';
+
+export const command = 'dev <command>';
+export const description = false;
+
+export const builder = function (yargs: yargs.Argv): yargs.Argv {
+  return yargs
+    .commandDir('dev-commands', {
+      extensions: ['js'],
+    })
+    .strict()
+    .demandCommand();
+};


### PR DESCRIPTION
I find myself often needing to create a test stack. I used to do this manually but have been hacking the demo command to do this for some time now.

I figured I might as well commit this. The command is hidden and can be invoked via `gt dev create-stack` or `gt dev cs` for short.