### PR TITLE
refactor(onto): expose onto method

### DIFF
--- a/scripts/installation/install_dev.sh
+++ b/scripts/installation/install_dev.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd $(dirname $0)
+npm install -g ../../

--- a/scripts/installation/install_nightly.sh
+++ b/scripts/installation/install_nightly.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+brew install screenplaydev/tap/graphite-nightly

--- a/scripts/installation/install_stable.sh
+++ b/scripts/installation/install_stable.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+brew install screenplaydev/tap/graphite

--- a/scripts/installation/uninstall.sh
+++ b/scripts/installation/uninstall.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+npm uninstall -g graphite-cli
+brew uninstall graphite
+brew uninstall graphite-nightly

--- a/src/actions/clean_branches.ts
+++ b/src/actions/clean_branches.ts
@@ -10,7 +10,7 @@ import { KilledError } from '../lib/errors';
 import { checkoutBranch, getTrunk, logInfo } from '../lib/utils';
 import Branch from '../wrapper-classes/branch';
 import { deleteBranchAction } from './delete_branch';
-import { ontoAction } from './onto';
+import { currentBranchOntoAction } from './onto/current_branch_onto';
 
 /**
  * This method is assumed to be idempotent -- if a merge conflict interrupts
@@ -119,7 +119,7 @@ export async function deleteMergedBranches(opts: {
       if (parentName !== undefined && parentName in branchesToDelete) {
         checkoutBranch(branch.name);
         logInfo(`upstacking (${branch.name}) onto (${getTrunk().name})`);
-        await ontoAction({
+        await currentBranchOntoAction({
           onto: getTrunk().name,
           mergeConflictCallstack: {
             frame: opts.frame,

--- a/src/actions/onto/current_branch_onto.ts
+++ b/src/actions/onto/current_branch_onto.ts
@@ -1,0 +1,24 @@
+import { MergeConflictCallstackT } from '../../lib/config/merge_conflict_callstack_config';
+import { PreconditionsFailedError } from '../../lib/errors';
+import { currentBranchPrecondition } from '../../lib/preconditions';
+import { checkoutBranch, trackedUncommittedChanges } from '../../lib/utils';
+import { stackOnto } from './stack_onto';
+
+export async function currentBranchOntoAction(args: {
+  onto: string;
+  mergeConflictCallstack: MergeConflictCallstackT;
+}): Promise<void> {
+  if (trackedUncommittedChanges()) {
+    throw new PreconditionsFailedError('Cannot fix with uncommitted changes');
+  }
+
+  const originalBranch = currentBranchPrecondition();
+
+  await stackOnto({
+    currentBranch: originalBranch,
+    onto: args.onto,
+    mergeConflictCallstack: args.mergeConflictCallstack,
+  });
+
+  checkoutBranch(originalBranch.name);
+}

--- a/src/commands/continue.ts
+++ b/src/commands/continue.ts
@@ -5,7 +5,7 @@ import { restackBranch, stackFixActionContinuation } from '../actions/fix';
 import {
   stackOntoBaseRebaseContinuation,
   stackOntoFixContinuation,
-} from '../actions/onto';
+} from '../actions/onto/stack_onto';
 import { repoSyncDeleteMergedBranchesContinuation } from '../actions/sync';
 import {
   clearPersistedMergeConflictCallstack,

--- a/src/commands/upstack-commands/onto.ts
+++ b/src/commands/upstack-commands/onto.ts
@@ -1,5 +1,5 @@
 import yargs from 'yargs';
-import { ontoAction } from '../../actions/onto';
+import { currentBranchOntoAction } from '../../actions/onto/current_branch_onto';
 import { profile } from '../../lib/telemetry';
 
 const args = {
@@ -20,7 +20,7 @@ export const builder = args;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, canonical, async () => {
-    await ontoAction({
+    await currentBranchOntoAction({
       onto: argv.branch,
       mergeConflictCallstack: 'TOP_OF_CALLSTACK_WITH_NOTHING_AFTER',
     });


### PR DESCRIPTION
For the upcoming `stack edit`, we'll need to expose the inner method on `onto`, such that we can use it to re-order stacks.
