### PR TITLE
test(edit): add first sanity check to downstack edit

### DIFF
--- a/src/actions/edit/create_stack_edit_file.ts
+++ b/src/actions/edit/create_stack_edit_file.ts
@@ -8,7 +8,10 @@ const FILE_HEADER = [`Op  `, `Branch`].join(COLUMN_SPACING);
 const FILE_DIVIDER = `-`.repeat(20);
 const FILE_FOOTER =
   '# p, pick = stack branch upon the branch from the previous line';
-export function createEditFile(opts: { stack: Stack; tmpDir: string }): string {
+export function createStackEditFile(opts: {
+  stack: Stack;
+  tmpDir: string;
+}): string {
   const branchNames = opts.stack.branches().map((b) => b.name);
   const fileContents = [
     FILE_HEADER,

--- a/src/commands/downstack-commands/edit.ts
+++ b/src/commands/downstack-commands/edit.ts
@@ -2,7 +2,15 @@ import yargs from 'yargs';
 import { editDownstack } from '../../actions/edit/edit_downstack';
 import { profile } from '../../lib/telemetry';
 
-const args = {} as const;
+const args = {
+  input: {
+    describe: `Path to file specifying stack edits. Using this argument skips prompting for stack edits and assumes the user has already formatted a list. Primarly used for unit tests.`,
+    demandOption: false,
+    default: false,
+    hidden: true,
+    type: 'string',
+  },
+} as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
 export const command = 'edit';
@@ -13,6 +21,6 @@ export const aliases = ['e'];
 
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, canonical, async () => {
-    await editDownstack();
+    await editDownstack(argv.input ? { inputPath: argv.input } : undefined);
   });
 };

--- a/test/fast/commands/downstack/edit.test.ts
+++ b/test/fast/commands/downstack/edit.test.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import fs from 'fs-extra';
+import path from 'path';
+import { performInTmpDir } from '../../../../src/lib/utils/perform_in_tmp_dir';
+import { BasicScene } from '../../../lib/scenes/basic_scene';
+import { configureTest } from '../../../lib/utils';
+
+function createStackEditsInput(opts: {
+  dirPath: string;
+  orderedBranches: string[];
+}): string {
+  const contents = opts.orderedBranches.map((b) => `pick ${b}`).join('\n');
+  const filePath = path.join(opts.dirPath, 'edits.txt');
+  fs.writeFileSync(filePath, contents);
+  return filePath;
+}
+
+for (const scene of [new BasicScene()]) {
+  describe(`(${scene}): downstack edit`, function () {
+    configureTest(this, scene);
+
+    it('Can make a no-op downstack edit without conflict or error', async () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.execCliCommand("branch create 'a' -m '2' -q");
+      scene.repo.createChange('3', 'b');
+      scene.repo.execCliCommand("branch create 'b' -m '3' -q");
+
+      await performInTmpDir((dirPath) => {
+        const inputPath = createStackEditsInput({
+          dirPath,
+          orderedBranches: ['main', 'a', 'b'],
+        });
+        expect(() =>
+          scene.repo.execCliCommand(`downstack edit --input "${inputPath}"`)
+        ).to.not.throw(Error);
+        expect(scene.repo.rebaseInProgress()).to.be.false;
+      });
+    });
+  });
+}


### PR DESCRIPTION
Downstack edit will need some solid unit testing in order to verify edge cases. Start a simple pattern with a sanity test and a hidden arg for input files to bypass prompting.
