### PR TITLE
feat(edit): invert stack order in edit file

### DIFF
--- a/src/actions/edit/create_stack_edit_file.ts
+++ b/src/actions/edit/create_stack_edit_file.ts
@@ -13,6 +13,7 @@ export function createStackEditFile(opts: {
   tmpDir: string;
 }): string {
   const branchNames = opts.stack.branches().map((b) => b.name);
+  branchNames.reverse(); // show the trunk at the bottom of the list to better match "upstack" and "downstack"
   const fileContents = [
     FILE_HEADER,
     FILE_DIVIDER,

--- a/src/actions/edit/parse_stack_edit_file.ts
+++ b/src/actions/edit/parse_stack_edit_file.ts
@@ -20,6 +20,8 @@ export function parseEditFile(opts: { filePath: string }): TStackEdit[] {
       return { type: lineParts[0] as TStackEditType, branchName: lineParts[1] };
     });
 
+  parsedEdit.reverse(); // put trunk at the start of the list in memory, despite being bottom of list in file.
+
   if (parsedEdit[0].branchName !== getTrunk().name) {
     throw new ExitFailedError(
       `Cannot edit stack to no longer be branched off trunk`

--- a/test/fast/commands/downstack/edit.test.ts
+++ b/test/fast/commands/downstack/edit.test.ts
@@ -28,7 +28,7 @@ for (const scene of [new BasicScene()]) {
       await performInTmpDir((dirPath) => {
         const inputPath = createStackEditsInput({
           dirPath,
-          orderedBranches: ['main', 'a', 'b'],
+          orderedBranches: ['b', 'a', 'main'],
         });
         expect(() =>
           scene.repo.execCliCommand(`downstack edit --input "${inputPath}"`)
@@ -46,7 +46,7 @@ for (const scene of [new BasicScene()]) {
       await performInTmpDir((dirPath) => {
         const inputPath = createStackEditsInput({
           dirPath,
-          orderedBranches: ['main', 'b', 'a'], // reverse the order
+          orderedBranches: ['a', 'b', 'main'], // reverse the order
         });
         expect(() =>
           scene.repo.execCliCommand(`downstack edit --input "${inputPath}"`)


### PR DESCRIPTION
**Context:**
Xiulung gave great feedback that we should order the edit list to show trunk at the bottom in order to better match the verbage of "upstack" and "downstack".
