### PR TITLE
feat(edit): show trunk branch as comment

### DIFF
--- a/src/actions/edit/create_stack_edit_file.ts
+++ b/src/actions/edit/create_stack_edit_file.ts
@@ -1,23 +1,29 @@
 import fs from 'fs-extra';
 import path from 'path';
+import { getTrunk } from '../../lib/utils';
 import Stack from '../../wrapper-classes/stack';
 
 const FILE_NAME = 'graphite_stack_edit';
 const COLUMN_SPACING = ' '.repeat(5);
-const FILE_HEADER = [`Op  `, `Branch`].join(COLUMN_SPACING);
-const FILE_DIVIDER = `-`.repeat(20);
+const FILE_HEADER = [`# Op`, `Branch`].join(COLUMN_SPACING);
+const FILE_DIVIDER = '# ' + `-`.repeat(20);
 const FILE_FOOTER =
   '# p, pick = stack branch upon the branch from the previous line';
 export function createStackEditFile(opts: {
   stack: Stack;
   tmpDir: string;
 }): string {
-  const branchNames = opts.stack.branches().map((b) => b.name);
+  const trunkName = getTrunk().name;
+  const branchNames = opts.stack
+    .branches()
+    .map((b) => b.name)
+    .filter((n) => n !== trunkName);
   branchNames.reverse(); // show the trunk at the bottom of the list to better match "upstack" and "downstack"
   const fileContents = [
     FILE_HEADER,
     FILE_DIVIDER,
     ...branchNames.map((b) => `pick${COLUMN_SPACING}${b}`),
+    `# pick   ${trunkName} (shown here for orientation)`,
     FILE_DIVIDER,
     FILE_FOOTER,
   ].join('\n');

--- a/src/actions/edit/parse_stack_edit_file.ts
+++ b/src/actions/edit/parse_stack_edit_file.ts
@@ -20,22 +20,18 @@ export function parseEditFile(opts: { filePath: string }): TStackEdit[] {
       return { type: lineParts[0] as TStackEditType, branchName: lineParts[1] };
     });
 
-  parsedEdit.reverse(); // put trunk at the start of the list in memory, despite being bottom of list in file.
+  parsedEdit.reverse();
 
-  if (parsedEdit[0].branchName !== getTrunk().name) {
-    throw new ExitFailedError(
-      `Cannot edit stack to no longer be branched off trunk`
-    );
+  if (parsedEdit.map((e) => e.branchName).includes(getTrunk().name)) {
+    throw new ExitFailedError(`Cannot perform edits on trunk branch`);
   }
 
-  return parsedEdit
-    .slice(1) // Remove the trunk
-    .map((parsedStackEdit, index) => {
-      // Assume all edits are PICKs for now
-      return {
-        type: parsedStackEdit.type,
-        branchName: parsedStackEdit.branchName,
-        onto: index === 0 ? getTrunk().name : parsedEdit[index].branchName,
-      };
-    });
+  return parsedEdit.map((parsedStackEdit, index) => {
+    // Assume all edits are PICKs for now
+    return {
+      type: parsedStackEdit.type,
+      branchName: parsedStackEdit.branchName,
+      onto: index === 0 ? getTrunk().name : parsedEdit[index - 1].branchName,
+    };
+  });
 }

--- a/test/fast/commands/downstack/edit.test.ts
+++ b/test/fast/commands/downstack/edit.test.ts
@@ -28,7 +28,7 @@ for (const scene of [new BasicScene()]) {
       await performInTmpDir((dirPath) => {
         const inputPath = createStackEditsInput({
           dirPath,
-          orderedBranches: ['b', 'a', 'main'],
+          orderedBranches: ['b', 'a'],
         });
         expect(() =>
           scene.repo.execCliCommand(`downstack edit --input "${inputPath}"`)
@@ -46,7 +46,7 @@ for (const scene of [new BasicScene()]) {
       await performInTmpDir((dirPath) => {
         const inputPath = createStackEditsInput({
           dirPath,
-          orderedBranches: ['a', 'b', 'main'], // reverse the order
+          orderedBranches: ['a', 'b'], // reverse the order
         });
         expect(() =>
           scene.repo.execCliCommand(`downstack edit --input "${inputPath}"`)


### PR DESCRIPTION
**Context:**
Integrate feedback from Tomas, such that we show the trunk branch commented out so users get orientated, but dont try to rearrange the trunk in the stack.
