### PR TITLE
feat(create_branch): empty commits

### DIFF
--- a/src/actions/print_stack.ts
+++ b/src/actions/print_stack.ts
@@ -116,7 +116,7 @@ function getBranchInfo(branch: Branch, config: TPrintStackConfig): string[] {
   );
 
   if (!branch.isTrunk()) {
-    const commits = branch.getCommitSHAs();
+    const commits = branch.getNonEmptyCommitSHAs();
     if (commits.length !== 0) {
       commits.forEach((commitSHA) => {
         const commit = new Commit(commitSHA);

--- a/src/lib/utils/single_commit.ts
+++ b/src/lib/utils/single_commit.ts
@@ -2,7 +2,7 @@ import { Commit } from '../../wrapper-classes';
 import Branch from '../../wrapper-classes/branch';
 
 export function getSingleCommitOnBranch(branch: Branch): Commit | null {
-  const commits = branch.getCommitSHAs();
+  const commits = branch.getNonEmptyCommitSHAs();
   if (commits.length !== 1) {
     return null;
   }

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -530,7 +530,7 @@ export default class Branch {
   }
 
   // Due to deprecate in favor of other functions.
-  public getCommitSHAs(): string[] {
+  public getNonEmptyCommitSHAs(): string[] {
     // We rely on meta here as the source of truth to handle the case where
     // the user has just created a new branch, but hasn't added any commits
     // - so both branch tips point to the same commit. Graphite knows that
@@ -544,7 +544,7 @@ export default class Branch {
 
     const commits = gpExecSync(
       {
-        command: `git rev-list ${parent}..${this.name}`,
+        command: `git rev-list ${parent}..${this.name} .`, // the trailing period skips empty commits
       },
       (_) => {
         // just soft-fail if we can't find the commits

--- a/test/fast/commands/log/short.test.ts
+++ b/test/fast/commands/log/short.test.ts
@@ -1,8 +1,8 @@
-import { expect } from "chai";
-import { execSync } from "child_process";
-import { TrailingProdScene } from "../../../lib/scenes";
-import { configureTest } from "../../../lib/utils";
-import fs from "fs-extra";
+import { expect } from 'chai';
+import { execSync } from 'child_process';
+import fs from 'fs-extra';
+import { TrailingProdScene } from '../../../lib/scenes';
+import { configureTest } from '../../../lib/utils';
 
 for (const scene of [new TrailingProdScene()]) {
   describe(`(${scene}): log short`, function () {
@@ -29,25 +29,32 @@ for (const scene of [new TrailingProdScene()]) {
       expect(() => scene.repo.execCliCommand(`log short`)).to.not.throw(Error);
     });
 
-    it('Errors if trunk has two branches pointing to one commit', () => {
+    it('Doesnt error when creating an empty branch because of empty commits', () => {
       scene.repo.execCliCommand(`branch create a`);
+      scene.repo.checkoutBranch('main');
+      expect(() => scene.repo.execCliCommand('log short')).to.not.throw(Error);
+    });
+
+    it('Errors if two branches point to the same commit', () => {
+      scene.repo.execCliCommand(`branch create a`);
+      execSync(`git -C ${scene.repo.dir} reset --hard HEAD~1`); // delete the empty commit.
       scene.repo.checkoutBranch('main');
       expect(() => scene.repo.execCliCommand('log short')).to.throw(Error);
     });
 
-    it("Works if branch and file have same name", () => {
-      const textFileName = "test.txt"
+    it('Works if branch and file have same name', () => {
+      const textFileName = 'test.txt';
       scene.repo.execCliCommand(`branch create ${textFileName}`);
 
       // Creates a commit with contents "a" in file "test.txt"
-      scene.repo.createChangeAndCommit("a");
+      scene.repo.createChangeAndCommit('a');
       expect(fs.existsSync(textFileName)).to.be.true;
 
-      scene.repo.checkoutBranch(textFileName)
+      scene.repo.checkoutBranch(textFileName);
 
       // gt log should work - using "test.txt" as a revision rather than a path
-      expect(() => scene.repo.execCliCommand("log")).to.not.throw(Error);
-      expect(() => scene.repo.execCliCommand("log short")).to.not.throw(Error);
+      expect(() => scene.repo.execCliCommand('log')).to.not.throw(Error);
+      expect(() => scene.repo.execCliCommand('log short')).to.not.throw(Error);
     });
   });
 }

--- a/test/fast/wrapper-classes/stack_builder.test.ts
+++ b/test/fast/wrapper-classes/stack_builder.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { SiblingBranchError } from '../../../src/lib/errors';
 import {
   GitStackBuilder,
   MetaStackBuilder,
@@ -131,21 +130,6 @@ for (const scene of allScenes) {
 
       expect(metaStack.equals(Stack.fromMap({ main: { a: {} } }))).to.be.true;
       expect(gitStack.equals(Stack.fromMap({ a: {} }))).to.be.true;
-    });
-
-    it('Throws an error if two git branches point to the same commit', () => {
-      scene.repo.createChange('a');
-      scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
-
-      expect(() =>
-        new GitStackBuilder().fullStackFromBranch(new Branch('a'))
-      ).to.not.throw(Error);
-
-      scene.repo.execCliCommand(`branch create "b" -q`);
-
-      expect(() =>
-        new GitStackBuilder().fullStackFromBranch(new Branch('a'))
-      ).to.throw(SiblingBranchError);
     });
 
     it('Can get just downstack from a branch', () => {


### PR DESCRIPTION
**Context:**
We've heard from users a desire to be able to create a branch without committing, and not get an error.

This change enables that workflow by having branch create support always making a commit, sometimes empty if no changes are staged. This does not mean that graphite supports two branches pointing to the same commit, like what happens if you merge a branch into another. However, it does enable the common case.

I considered adding work to try and delete empty commits when possible, but based on research I think git already does that for us when operations like rebases happen. All tests are still passing as expected, so I figure we can try this for now.
