### PR TITLE
fix(empty_branch): better commit message

### DIFF
--- a/src/actions/print_stack.ts
+++ b/src/actions/print_stack.ts
@@ -116,7 +116,7 @@ function getBranchInfo(branch: Branch, config: TPrintStackConfig): string[] {
   );
 
   if (!branch.isTrunk()) {
-    const commits = branch.getNonEmptyCommitSHAs();
+    const commits = branch.getCommitSHAs();
     if (commits.length !== 0) {
       commits.forEach((commitSHA) => {
         const commit = new Commit(commitSHA);

--- a/src/lib/utils/single_commit.ts
+++ b/src/lib/utils/single_commit.ts
@@ -2,7 +2,7 @@ import { Commit } from '../../wrapper-classes';
 import Branch from '../../wrapper-classes/branch';
 
 export function getSingleCommitOnBranch(branch: Branch): Commit | null {
-  const commits = branch.getNonEmptyCommitSHAs();
+  const commits = branch.getCommitSHAs();
   if (commits.length !== 1) {
     return null;
   }

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -4,7 +4,7 @@ import { ExitFailedError, PreconditionsFailedError } from '../lib/errors';
 import {
   getBranchChildrenOrParentsFromGit,
   getRef,
-  otherBranchesWithSameCommit,
+  otherBranchesWithSameCommit
 } from '../lib/git-refs';
 import { getCommitterDate, getTrunk, gpExecSync, logDebug } from '../lib/utils';
 import Commit from './commit';
@@ -530,7 +530,7 @@ export default class Branch {
   }
 
   // Due to deprecate in favor of other functions.
-  public getNonEmptyCommitSHAs(): string[] {
+  public getCommitSHAs(): string[] {
     // We rely on meta here as the source of truth to handle the case where
     // the user has just created a new branch, but hasn't added any commits
     // - so both branch tips point to the same commit. Graphite knows that
@@ -544,7 +544,7 @@ export default class Branch {
 
     const commits = gpExecSync(
       {
-        command: `git rev-list ${parent}..${this.name} .`, // the trailing period skips empty commits
+        command: `git rev-list ${parent}..${this.name}`,
       },
       (_) => {
         // just soft-fail if we can't find the commits

--- a/test/fast/actions/submit_action.test.ts
+++ b/test/fast/actions/submit_action.test.ts
@@ -13,7 +13,8 @@ for (const scene of [new BasicScene()]) {
       const title = 'Test Title';
       const body = ['Test body line 1.', 'Test body line 2.'].join('\n');
 
-      scene.repo.execCliCommand(`branch create "a" -q`);
+      scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
+      execSync(`git reset HEAD~1 --hard`);
       scene.repo.createChange('a');
       execSync(`git commit -m "${title}" -m "${body}"`);
 
@@ -25,8 +26,7 @@ for (const scene of [new BasicScene()]) {
 
     it('can infer just title with no body', async () => {
       const title = 'Test Title';
-
-      const commitMessage = `${title}`;
+      const commitMessage = title;
 
       scene.repo.createChange('a');
       scene.repo.execCliCommand(`branch create "a" -m "${commitMessage}" -q`);
@@ -38,8 +38,7 @@ for (const scene of [new BasicScene()]) {
 
     it('does not infer title/body for multiple commits', async () => {
       const title = 'Test Title';
-
-      const commitMessage = `${title}`;
+      const commitMessage = title;
 
       scene.repo.createChange('a');
       scene.repo.execCliCommand(`branch create "a" -m "${commitMessage}" -q`);

--- a/test/fast/commands/branch/branch_create.test.ts
+++ b/test/fast/commands/branch/branch_create.test.ts
@@ -8,7 +8,7 @@ for (const scene of allScenes) {
     configureTest(this, scene);
 
     it('Can run branch create', () => {
-      scene.repo.execCliCommand(`branch create "a" -q`);
+      scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
       expect(scene.repo.currentBranchName()).to.equal('a');
       scene.repo.createChangeAndCommit('2', '2');
 

--- a/test/fast/commands/branch/branch_delete.test.ts
+++ b/test/fast/commands/branch/branch_delete.test.ts
@@ -13,7 +13,9 @@ for (const scene of allScenes) {
       const branchName = 'a';
 
       scene.repo.createChangeAndCommit('2', '2');
-      scene.repo.execCliCommand(`branch create "${branchName}" -q`);
+      scene.repo.execCliCommand(
+        `branch create "${branchName}" -m "${branchName}" -q`
+      );
       expect(scene.repo.currentBranchName()).to.equal(branchName);
 
       scene.repo.checkoutBranch('main');

--- a/test/fast/commands/log/short.test.ts
+++ b/test/fast/commands/log/short.test.ts
@@ -30,13 +30,13 @@ for (const scene of [new TrailingProdScene()]) {
     });
 
     it('Doesnt error when creating an empty branch because of empty commits', () => {
-      scene.repo.execCliCommand(`branch create a`);
+      scene.repo.execCliCommand(`branch create a -m "a"`);
       scene.repo.checkoutBranch('main');
       expect(() => scene.repo.execCliCommand('log short')).to.not.throw(Error);
     });
 
     it('Errors if two branches point to the same commit', () => {
-      scene.repo.execCliCommand(`branch create a`);
+      scene.repo.execCliCommand(`branch create a -m "a"`);
       execSync(`git -C ${scene.repo.dir} reset --hard HEAD~1`); // delete the empty commit.
       scene.repo.checkoutBranch('main');
       expect(() => scene.repo.execCliCommand('log short')).to.throw(Error);
@@ -44,7 +44,7 @@ for (const scene of [new TrailingProdScene()]) {
 
     it('Works if branch and file have same name', () => {
       const textFileName = 'test.txt';
-      scene.repo.execCliCommand(`branch create ${textFileName}`);
+      scene.repo.execCliCommand(`branch create ${textFileName} -m "a"`);
 
       // Creates a commit with contents "a" in file "test.txt"
       scene.repo.createChangeAndCommit('a');

--- a/test/fast/wrapper-classes/branch.test.ts
+++ b/test/fast/wrapper-classes/branch.test.ts
@@ -17,7 +17,7 @@ for (const scene of allScenes) {
 
     it('Can list parent based on meta for a branch', () => {
       scene.repo.createChange('2');
-      scene.repo.execCliCommand(`branch create "a" -q`);
+      scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
 
       const branch = new Branch('a');
       expect(branch.getParentFromMeta()).is.not.undefined;

--- a/test/fast/yargs/two_letter_shortcuts.test.ts
+++ b/test/fast/yargs/two_letter_shortcuts.test.ts
@@ -7,7 +7,7 @@ for (const scene of [new BasicScene()]) {
     configureTest(this, scene);
 
     it("Can run 'bn' shortcut command", () => {
-      scene.repo.execCliCommand(`branch create "a" -q`);
+      scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
       scene.repo.checkoutBranch('main');
       expect(() =>
         scene.repo.execCliCommand('bn --no-interactive')


### PR DESCRIPTION
**Context:**
When we create empty commits, they currently get a message of "undefined". Let's fix that such:

* if the user passes a -m, we use the message
* Otherwise, we show the standard commit message prompt and add comments to explain why the empty commit is coming into existance.
